### PR TITLE
Update uses of 'fileprivate' with 'private'

### DIFF
--- a/Client/Helpers/SFSafariViewController+PreviewActionItems.swift
+++ b/Client/Helpers/SFSafariViewController+PreviewActionItems.swift
@@ -15,7 +15,7 @@ private struct AssociatedKeys {
 }
 
 extension SFSafariViewController {
-    fileprivate(set) public var initialURL: URL? {
+    private(set) public var initialURL: URL? {
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.InitialURL, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }

--- a/Client/PostTitleView.swift
+++ b/Client/PostTitleView.swift
@@ -43,7 +43,7 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
         }
     }
     
-    fileprivate func domainLabelText(for post: HNPost) -> String {
+    private func domainLabelText(for post: HNPost) -> String {
         guard let urlComponents = URLComponents(string: post.urlString), var host = urlComponents.host else {
             return "news.ycombinator.com"
         }
@@ -55,7 +55,7 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
         return host
     }
     
-    fileprivate func metadataText(for post: HNPost) -> NSAttributedString {
+    private func metadataText(for post: HNPost) -> NSAttributedString {
         let string = NSMutableAttributedString()
         
         let pointsIconAttachment = textAttachment(for: "PointsIcon")
@@ -73,13 +73,13 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
         return string
     }
     
-    fileprivate func templateImage(named: String) -> UIImage? {
+    private func templateImage(named: String) -> UIImage? {
         let image = UIImage.init(named: named)
         let templateImage = image?.withRenderingMode(.alwaysTemplate)
         return templateImage
     }
     
-    fileprivate func textAttachment(for imageNamed: String) -> NSTextAttachment {
+    private func textAttachment(for imageNamed: String) -> NSTextAttachment {
         let attachment = NSTextAttachment()
         guard let image = templateImage(named: imageNamed) else { return attachment }
         attachment.image = image

--- a/Client/ReviewController.swift
+++ b/Client/ReviewController.swift
@@ -9,8 +9,8 @@
 import StoreKit
 
 class ReviewController {
-    fileprivate static let showPromptIncrements = [5, 10, 15]
-    fileprivate static let LaunchCounter = "Launch Counter"
+    private static let showPromptIncrements = [5, 10, 15]
+    private static let LaunchCounter = "Launch Counter"
     
     static func incrementLaunchCounter() {
         let counter = launchCounter()


### PR DESCRIPTION
The project currently uses Swift 4.1 so replacing `fileprivate` with
`private` makes sense in most cases.

See Swift Proposal SE-0169 for details.