### PR TITLE
Adding jobs tab enabling setting (enabled by default)

### DIFF
--- a/Client/Main.storyboard
+++ b/Client/Main.storyboard
@@ -205,7 +205,7 @@
                 <navigationController id="2FT-kg-cd5" customClass="AppNavigationController" customModule="Hackers" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="aiG-Km-7Il"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="o2Y-R6-LxE">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -649,6 +649,42 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection id="6HR-Zh-zQj">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="dmH-R0-5HV" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="115" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dmH-R0-5HV" id="Uev-9n-7Kx">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Jobs tab" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gZS-fS-7b0">
+                                                    <rect key="frame" x="16" y="11.5" width="66.5" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Md-rl-Lg9">
+                                                    <rect key="frame" x="311" y="6.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="jobsValueChanged:" destination="uZL-eS-tCe" eventType="valueChanged" id="lTt-9j-2YM"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="4Md-rl-Lg9" firstAttribute="centerY" secondItem="Uev-9n-7Kx" secondAttribute="centerY" id="7lZ-nS-ZHp"/>
+                                                <constraint firstItem="gZS-fS-7b0" firstAttribute="centerY" secondItem="Uev-9n-7Kx" secondAttribute="centerY" id="JXo-dB-67k"/>
+                                                <constraint firstAttribute="trailing" secondItem="4Md-rl-Lg9" secondAttribute="trailing" constant="15" id="Npp-x0-Zsg"/>
+                                                <constraint firstItem="gZS-fS-7b0" firstAttribute="leading" secondItem="Uev-9n-7Kx" secondAttribute="leadingMargin" id="XYc-fX-SXO"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <connections>
+                                            <outlet property="titleLabel" destination="gZS-fS-7b0" id="tZb-Jm-Fjx"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="uZL-eS-tCe" id="qU2-ix-dVN"/>
@@ -664,6 +700,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="darkModeSwitch" destination="uAe-yS-ppv" id="54F-9Q-wfy"/>
+                        <outlet property="jobsSwitch" destination="4Md-rl-Lg9" id="32F-mm-Psz"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KhC-65-Tqy" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -700,6 +737,6 @@
         <image name="ThumbnailPlaceholderIcon" width="42" height="42"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="vbE-ZV-SDt"/>
+        <segue reference="N2W-56-WNc"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Client/MainTabBarController.swift
+++ b/Client/MainTabBarController.swift
@@ -10,11 +10,15 @@ import UIKit
 import libHN
 
 class MainTabBarController: UITabBarController {
+    private var defaultTabs : [UIViewController]?
+    private let jobsTabIndex : Int = 2
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTheming()
         
         guard let viewControllers = self.viewControllers else { return }
+        if (self.defaultTabs == nil) { self.defaultTabs = viewControllers }
         
         for (index, viewController) in viewControllers.enumerated() {
             guard let splitViewController = viewController as? UISplitViewController,
@@ -33,6 +37,16 @@ class MainTabBarController: UITabBarController {
         tabBar.clipsToBounds = true
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        if (UserDefaults.standard.jobsEnabled) {
+            setViewControllers(defaultTabs, animated: false)
+        } else {
+            var updatedTabs = self.defaultTabs
+            updatedTabs?.remove(at: jobsTabIndex)
+            setViewControllers(updatedTabs, animated: false)
+        }
+    }
+
     private func tabItems(for index: Int) -> (PostFilterType, String, String) {
         var postType = PostFilterType.top
         var typeName = "Top"
@@ -48,7 +62,7 @@ class MainTabBarController: UITabBarController {
             typeName = "Ask"
             iconName = "AskIcon"
             break
-        case 2:
+        case jobsTabIndex:
             postType = .jobs
             typeName = "Jobs"
             iconName = "JobsIcon"

--- a/Client/Settings/Settings+UserDefaultsExtensions.swift
+++ b/Client/Settings/Settings+UserDefaultsExtensions.swift
@@ -11,12 +11,24 @@ extension UserDefaults {
         let themeSetting = string(forKey: UserDefaultsKeys.Theme.rawValue)
         return themeSetting == "dark"
     }
-    
+
+    public var jobsEnabled: Bool {
+        let jobsEnabled = string(forKey:
+            UserDefaultsKeys.Jobs.rawValue)
+        return jobsEnabled == "enabled"
+    }
+
     public func setDarkMode(_ enabled: Bool) {
         set(enabled ? "dark" : "light", forKey: UserDefaultsKeys.Theme.rawValue)
     }
+
+    public func setJobsEnabled(_ enabled: Bool) {
+        set(enabled ? "enabled" : "disabled", forKey: UserDefaultsKeys.Jobs.rawValue)
+    }
+
 }
 
 enum UserDefaultsKeys: String {
     case Theme
+    case Jobs
 }

--- a/Client/Settings/SettingsViewController.swift
+++ b/Client/Settings/SettingsViewController.swift
@@ -9,12 +9,14 @@
 import UIKit
 
 class SettingsViewController: UITableViewController {
+    @IBOutlet weak var jobsSwitch: UISwitch!
     @IBOutlet weak var darkModeSwitch: UISwitch!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTheming()
         darkModeSwitch.isOn = UserDefaults.standard.darkModeEnabled
+        jobsSwitch.setOn(UserDefaults.standard.jobsEnabled, animated: false)
     }
     
     @IBAction func darkModeValueChanged(_ sender: UISwitch) {
@@ -22,6 +24,10 @@ class SettingsViewController: UITableViewController {
         AppThemeProvider.shared.currentTheme = sender.isOn ? .dark : .light
     }
     
+    @IBAction func jobsValueChanged(_ sender: UISwitch) {
+        UserDefaults.standard.setJobsEnabled(sender.isOn)
+    }
+
     @IBAction func didPressDone(_ sender: Any) {
         dismiss(animated: true)
     }


### PR DESCRIPTION
Adding a "Jobs tab" setting so that you can hide the Jobs tab if you don't need it. 
It's ON by default so this PR does not change the default of having the 4 tabs.

Rationale: I'm not always interested in checking Jobs so I'd like to be able to hide it.

Thanks in advance

<img width="505" alt="captura de pantalla 2018-10-21 a las 0 48 39" src="https://user-images.githubusercontent.com/251096/47261249-1fb1dd80-d4cb-11e8-834c-0e4026537cc0.png">
