### PR TITLE
Migrate to HNScraper

### DIFF
--- a/Client/Comments/CommentTableViewCell.swift
+++ b/Client/Comments/CommentTableViewCell.swift
@@ -58,7 +58,7 @@ class CommentTableViewCell : UITableViewCell {
             let commentTextColor = AppThemeProvider.shared.currentTheme.textColor
             let lineSpacing = 4 as CGFloat
             
-            let commentAttributedString = NSMutableAttributedString(string: comment.text)
+            let commentAttributedString = NSMutableAttributedString(string: comment.text.parsedHTML())
             let paragraphStyle = NSMutableParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
             paragraphStyle.lineSpacing = lineSpacing
             

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -85,7 +85,8 @@ class CommentsViewController : UIViewController {
     }
     
     @IBAction func shareTapped(_ sender: AnyObject) {
-        let activityViewController = UIActivityViewController(activityItems: [post!.title, post!.url], applicationActivities: nil)
+        guard let post = post, let url = post.url else { return }
+        let activityViewController = UIActivityViewController(activityItems: [post.title, url], applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = sender as? UIBarButtonItem
         present(activityViewController, animated: true, completion: nil)
     }

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -62,7 +62,7 @@ class CommentsViewController : UIViewController {
     }
     
     func loadComments() {
-        HNScraper.shared.getComments(ForPost: post!) { (post, comments, error) in
+        HNScraper.shared.getComments(ForPost: post!, buildHierarchy: false) { (post, comments, error) in
             self.view.hideSkeleton()
             self.tableView.rowHeight = UITableView.automaticDimension
             let mappedComments = comments.map { CommentModel(source: $0) }

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -9,9 +9,9 @@
 import Foundation
 import UIKit
 import SafariServices
-import libHN
 import DZNEmptyDataSet
 import SkeletonView
+import HNScraper
 
 class CommentsViewController : UIViewController {
     var post: HNPost?
@@ -62,16 +62,11 @@ class CommentsViewController : UIViewController {
     }
     
     func loadComments() {
-        HNManager.shared().loadComments(from: post) { comments in
-            if let downcastedArray = comments as? [HNComment] {
-                let mappedComments = downcastedArray.map { CommentModel(source: $0) }
-                self.comments = mappedComments
-            } else {
-                self.comments = [CommentModel]()
-            }
-            
+        HNScraper.shared.getComments(ForPost: post!) { (post, comments, error) in
             self.view.hideSkeleton()
             self.tableView.rowHeight = UITableView.automaticDimension
+            let mappedComments = comments.map { CommentModel(source: $0) }
+            self.comments = mappedComments
             self.tableView.reloadData()
         }
     }
@@ -82,7 +77,7 @@ class CommentsViewController : UIViewController {
         postTitleView.post = post
         postTitleView.delegate = self
         postTitleView.isTitleTapEnabled = true
-        thumbnailImageView.setImageWithPlaceholder(urlString: post.urlString)
+        thumbnailImageView.setImageWithPlaceholder(url: post.url)
     }
     
     @IBAction func didTapThumbnail(_ sender: Any) {
@@ -90,7 +85,7 @@ class CommentsViewController : UIViewController {
     }
     
     @IBAction func shareTapped(_ sender: AnyObject) {
-        let activityViewController = UIActivityViewController(activityItems: [post!.title, URL(string: post!.urlString)!], applicationActivities: nil)
+        let activityViewController = UIActivityViewController(activityItems: [post!.title, post!.url], applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = sender as? UIBarButtonItem
         present(activityViewController, animated: true, completion: nil)
     }
@@ -98,7 +93,7 @@ class CommentsViewController : UIViewController {
 
 extension CommentsViewController: PostTitleViewDelegate {
     func didPressLinkButton(_ post: HNPost) {
-        if verifyLink(post.urlString), let url = URL(string: post.urlString) {
+        if verifyLink(post.url), let url = post.url {
             // animate background colour for tap
             self.tableView.tableHeaderView?.backgroundColor = AppThemeProvider.shared.currentTheme.cellHighlightColor
             UIView.animate(withDuration: 0.3, animations: {
@@ -111,10 +106,8 @@ extension CommentsViewController: PostTitleViewDelegate {
         }
     }
     
-    func verifyLink(_ urlString: String?) -> Bool {
-        guard let urlString = urlString, let url = URL(string: urlString) else {
-            return false
-        }
+    func verifyLink(_ url: URL?) -> Bool {
+        guard let url = url else { return false }
         return UIApplication.shared.canOpenURL(url)
     }
 }

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -62,7 +62,7 @@ class CommentsViewController : UIViewController {
     }
     
     func loadComments() {
-        HNScraper.shared.getComments(ForPost: post!, buildHierarchy: false) { (post, comments, error) in
+        HNScraper.shared.getComments(ForPost: post!, buildHierarchy: false, offsetComments: false) { (post, comments, error) in
             self.view.hideSkeleton()
             self.tableView.rowHeight = UITableView.automaticDimension
             let mappedComments = comments.map { CommentModel(source: $0) }

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -32,7 +32,7 @@ class CommentsViewController : UIViewController {
         super.viewDidLoad()
         setupTheming()
         setupPostTitleView()
-        view.showAnimatedSkeleton(usingColor: AppThemeProvider.shared.currentTheme.skeletonColor)
+        view.showAnimatedGradientSkeleton(usingGradient: SkeletonGradient(baseColor: AppThemeProvider.shared.currentTheme.skeletonColor))
         loadComments()
     }
     

--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -196,7 +196,7 @@ extension CommentsViewController: DZNEmptyDataSetSource, DZNEmptyDataSetDelegate
 }
 
 extension CommentsViewController: SkeletonTableViewDataSource {
-    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
         return "SkeletonCell"
     }
 }

--- a/Client/Helpers/StringExtensions.swift
+++ b/Client/Helpers/StringExtensions.swift
@@ -27,3 +27,60 @@ extension String {
         }
     }
 }
+
+extension String {
+    subscript (bounds: CountableClosedRange<Int>) -> String {
+        let start = index(startIndex, offsetBy: bounds.lowerBound)
+        let end = index(startIndex, offsetBy: bounds.upperBound)
+        return String(self[start...end])
+    }
+    
+    subscript (bounds: CountableRange<Int>) -> String {
+        let start = index(startIndex, offsetBy: bounds.lowerBound)
+        let end = index(startIndex, offsetBy: bounds.upperBound)
+        return String(self[start..<end])
+    }
+}
+
+extension String {
+    func parsedHTML() -> String {
+        var text = self
+        text = text.replacingOccurrences(of: "<p>", with: "\n\n")
+        text = text.replacingOccurrences(of: "</p>", with: "")
+        text = text.replacingOccurrences(of: "<i>", with: "")
+        text = text.replacingOccurrences(of: "</i>", with: "")
+        text = text.replacingOccurrences(of: "&#38;", with: "&")
+        text = text.replacingOccurrences(of: "&#62;", with: ">")
+        text = text.replacingOccurrences(of: "&#x27;", with: "'")
+        text = text.replacingOccurrences(of: "&#x2F;", with: "/")
+        text = text.replacingOccurrences(of: "&quot;", with: "\"")
+        text = text.replacingOccurrences(of: "&#60;", with: "<")
+        text = text.replacingOccurrences(of: "&lt;", with: "<")
+        text = text.replacingOccurrences(of: "&gt;", with: ">")
+        text = text.replacingOccurrences(of: "&amp;", with: "")
+        text = text.replacingOccurrences(of: "<pre><code>", with: "")
+        text = text.replacingOccurrences(of: "</code></pre>", with: "")
+        
+        let scanner = Scanner(string: text)
+        scanner.charactersToBeSkipped = CharacterSet(charactersIn: "")
+        var goodText: NSString?, runningString: NSString = "", trash: NSString?
+        
+        while !scanner.isAtEnd {
+            if scanner.string[scanner.scanLocation...].range(of: "<a href") != nil {
+                scanner.scanUpTo("<a href=", into: &goodText)
+                runningString = runningString.appending(goodText! as String) as NSString
+                scanner.scanString("<a href=\"", into: &trash)
+                scanner.scanUpTo("\"", into: &goodText)
+                runningString = runningString.appending(goodText! as String) as NSString
+                scanner.scanUpTo("</a>", into: &trash)
+                scanner.scanString("</a>", into: &trash)
+            } else {
+                let string = scanner.string[scanner.scanLocation...]
+                runningString = runningString.appending(String(string)) as NSString
+                scanner.scanLocation = text.count
+            }
+        }
+        
+        return runningString as String
+    }
+}

--- a/Client/Helpers/StringExtensions.swift
+++ b/Client/Helpers/StringExtensions.swift
@@ -63,7 +63,7 @@ extension String {
         
         let scanner = Scanner(string: text)
         scanner.charactersToBeSkipped = CharacterSet(charactersIn: "")
-        var goodText: NSString?, runningString: NSString = "", trash: NSString?
+        var goodText: NSString? = "", runningString: NSString = "", trash: NSString?
         
         while !scanner.isAtEnd {
             if scanner.string[scanner.scanLocation...].range(of: "<a href") != nil {

--- a/Client/Helpers/ThumbnailFetcher.swift
+++ b/Client/Helpers/ThumbnailFetcher.swift
@@ -9,11 +9,11 @@
 import Kingfisher
 
 extension UIImageView {
-    func setImageWithPlaceholder(urlString: String) {
+    func setImageWithPlaceholder(url: URL?) {
         let placeholderImage = UIImage(named: "ThumbnailPlaceholderIcon")?.withRenderingMode(.alwaysTemplate)
         self.image = placeholderImage
-        if let url = URL(string: "https://image-extractor.now.sh/?url=" + urlString) {
-            self.kf.setImage(with: url, placeholder: placeholderImage)
+        if let url = url, let thumbnailURL = URL(string: "https://image-extractor.now.sh/?url=" + url.absoluteString) {
+            self.kf.setImage(with: thumbnailURL, placeholder: placeholderImage)
         }
     }
 }

--- a/Client/MainSplitViewController.swift
+++ b/Client/MainSplitViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import libHN
 
 class MainSplitViewController: UISplitViewController, UISplitViewControllerDelegate {
     required init?(coder aDecoder: NSCoder) {

--- a/Client/MainTabBarController.swift
+++ b/Client/MainTabBarController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import libHN
+import HNScraper
 
 class MainTabBarController: UITabBarController {
     override func viewDidLoad() {
@@ -33,18 +33,18 @@ class MainTabBarController: UITabBarController {
         tabBar.clipsToBounds = true
     }
     
-    private func tabItems(for index: Int) -> (PostFilterType, String, String) {
-        var postType = PostFilterType.top
+    private func tabItems(for index: Int) -> (HNScraper.PostListPageName, String, String) {
+        var postType = HNScraper.PostListPageName.news
         var typeName = "Top"
         var iconName = "TopIcon"
         
         switch index {
         case 0:
-            postType = .top
+            postType = .news
             typeName = "Top"
             iconName = "TopIcon"
         case 1:
-            postType = .ask
+            postType = .asks
             typeName = "Ask"
             iconName = "AskIcon"
             break

--- a/Client/PostTitleView.swift
+++ b/Client/PostTitleView.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import libHN
+import HNScraper
 
 protocol PostTitleViewDelegate {
     func didPressLinkButton(_ post: HNPost)
@@ -44,7 +44,9 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
     }
     
     private func domainLabelText(for post: HNPost) -> String {
-        guard let urlComponents = URLComponents(string: post.urlString), var host = urlComponents.host else {
+        guard let url = post.url,
+            let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            var host = urlComponents.host else {
             return "news.ycombinator.com"
         }
         

--- a/Client/Posts List/NewsViewController.swift
+++ b/Client/Posts List/NewsViewController.swift
@@ -182,7 +182,7 @@ extension NewsViewController: Themed {
 }
 
 extension NewsViewController: SkeletonTableViewDataSource {
-    func collectionSkeletonView(_ skeletonView: UITableView, cellIdenfierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
+    func collectionSkeletonView(_ skeletonView: UITableView, cellIdentifierForRowAt indexPath: IndexPath) -> ReusableCellIdentifier {
         return "SkeletonCell"
     }
 }

--- a/Client/Posts List/NewsViewController.swift
+++ b/Client/Posts List/NewsViewController.swift
@@ -35,7 +35,7 @@ class NewsViewController : UIViewController {
         
         setupTheming()
         
-        view.showAnimatedSkeleton(usingColor: AppThemeProvider.shared.currentTheme.skeletonColor)
+        view.showAnimatedGradientSkeleton(usingGradient: SkeletonGradient(baseColor: AppThemeProvider.shared.currentTheme.skeletonColor))
         loadPosts()
     }
     

--- a/Client/Supporting Files/AppDelegate.swift
+++ b/Client/Supporting Files/AppDelegate.swift
@@ -6,14 +6,11 @@
 //  Copyright (c) 2014 Glass Umbrella. All rights reserved.
 //
 
-import libHN
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func applicationDidFinishLaunching(_ application: UIApplication) {
-        HNManager.shared().startSession()
         ReviewController.incrementLaunchCounter()
         ReviewController.requestReview()
         setAppTheme()

--- a/Client/Supporting Files/Hackers2-Bridging-Header.h
+++ b/Client/Supporting Files/Hackers2-Bridging-Header.h
@@ -2,5 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <libHN/libHN.h>
 #import <DZNEmptyDataSet/UIScrollView+EmptyDataSet.h>

--- a/Hackers.xcodeproj/project.pbxproj
+++ b/Hackers.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Hackers/Pods-Hackers-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DZNEmptyDataSet/DZNEmptyDataSet.framework",
+				"${BUILT_PRODUCTS_DIR}/HNScraper/HNScraper.framework",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
 				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
 				"${BUILT_PRODUCTS_DIR}/SkeletonView/SkeletonView.framework",
@@ -393,6 +394,7 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DZNEmptyDataSet.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/HNScraper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SkeletonView.framework",

--- a/Hackers.xcodeproj/project.pbxproj
+++ b/Hackers.xcodeproj/project.pbxproj
@@ -389,7 +389,6 @@
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
 				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
 				"${BUILT_PRODUCTS_DIR}/SkeletonView/SkeletonView.framework",
-				"${BUILT_PRODUCTS_DIR}/libHN/libHN.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -398,7 +397,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SkeletonView.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libHN.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Models/CommentModel.swift
+++ b/Models/CommentModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import libHN
+import HNScraper
 
 enum CommentVisibilityType: Int {
     case visible = 3
@@ -17,7 +17,7 @@ enum CommentVisibilityType: Int {
 
 class CommentModel {
     
-    var type: HNCommentType
+    var type: HNComment.HNCommentType
     var text: String
     var authorUsername: String
     var commentID: String
@@ -29,14 +29,14 @@ class CommentModel {
     var visibility: CommentVisibilityType = .visible
     
     init(source: HNComment) {
-        type = HNCommentType.default
+        type = source.type
         authorUsername = source.username
-        commentID = source.commentId
+        commentID = source.id
         //parentCommentID = source.ParentID
         parentCommentID = ""
-        dateCreatedString = source.timeCreatedString
-        if let _ = source.replyURLString {
-            replyURL = URL(string: source.replyURLString!)
+        dateCreatedString = source.created
+        if let _ = source.replyUrl {
+            replyURL = URL(string: source.replyUrl)
         }
         level = Int(source.level)
         text = source.text

--- a/Podfile
+++ b/Podfile
@@ -4,8 +4,7 @@ inhibit_all_warnings!
 
 target 'Hackers' do
   pod 'HNScraper'
-  pod 'libHN', :git => 'https://github.com/weiran/libHN', :commit => '6759f4ac591f5f36b01158260627ba0bf36eddc1'
-	pod 'DZNEmptyDataSet'
+  pod 'DZNEmptyDataSet'
   pod 'PromiseKit', '~> 4.x'
   pod 'SkeletonView'
   pod 'Kingfisher'

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    if ['PromiseKit', 'SkeletonView'].include? target.name
+    if ['PromiseKit'].include? target.name
       target.build_configurations.each do |config|
         config.build_settings['SWIFT_VERSION'] = '4.0'
       end

--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'Hackers' do
+  pod 'HNScraper'
   pod 'libHN', :git => 'https://github.com/weiran/libHN', :commit => '6759f4ac591f5f36b01158260627ba0bf36eddc1'
 	pod 'DZNEmptyDataSet'
   pod 'PromiseKit', '~> 4.x'

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'Hackers' do
-  pod 'HNScraper'
+  pod 'HNScraper', :git => 'https://github.com/weiran/HNScraper.git'
   pod 'DZNEmptyDataSet'
   pod 'PromiseKit', '~> 4.x'
   pod 'SkeletonView'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
 
 DEPENDENCIES:
   - DZNEmptyDataSet
-  - HNScraper
+  - HNScraper (from `https://github.com/weiran/HNScraper.git`)
   - Kingfisher
   - PromiseKit (~> 4.x)
   - SkeletonView
@@ -25,10 +25,18 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - DZNEmptyDataSet
-    - HNScraper
     - Kingfisher
     - PromiseKit
     - SkeletonView
+
+EXTERNAL SOURCES:
+  HNScraper:
+    :git: https://github.com/weiran/HNScraper.git
+
+CHECKOUT OPTIONS:
+  HNScraper:
+    :commit: 54b3e0f1b3ced275d6558f6d0a801d60a120cc66
+    :git: https://github.com/weiran/HNScraper.git
 
 SPEC CHECKSUMS:
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
@@ -37,6 +45,6 @@ SPEC CHECKSUMS:
   PromiseKit: 743e497a5f505a470d3bbbf4ce0663c1268af0a4
   SkeletonView: 60d6ce7edb0cb4c7758db33c74add50392b3c475
 
-PODFILE CHECKSUM: e10813922852ca5d7db1459262dc07413462b789
+PODFILE CHECKSUM: f7a77b564eaefb9e9172b5736f0ad5a19a970a48
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - DZNEmptyDataSet (1.8.1)
+  - HNScraper (0.2.2)
   - Kingfisher (4.8.1)
   - libHN (4.1.0)
   - PromiseKit (4.5.2):
@@ -17,6 +18,7 @@ PODS:
 
 DEPENDENCIES:
   - DZNEmptyDataSet
+  - HNScraper
   - Kingfisher
   - libHN (from `https://github.com/weiran/libHN`, commit `6759f4ac591f5f36b01158260627ba0bf36eddc1`)
   - PromiseKit (~> 4.x)
@@ -25,6 +27,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - DZNEmptyDataSet
+    - HNScraper
     - Kingfisher
     - PromiseKit
     - SkeletonView
@@ -41,11 +44,12 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
+  HNScraper: 89d135811bc8b9088adbb677c0bbc6cf8ed85cc0
   Kingfisher: 868c1149679a7ab6869be118faa9b5aed154aaf0
   libHN: fe671e9d39466235239b793f1f0181baadb327b2
   PromiseKit: 743e497a5f505a470d3bbbf4ce0663c1268af0a4
   SkeletonView: 041053e904504e7d8db83df166e599be75659fe1
 
-PODFILE CHECKSUM: 64e06282b3a5267d2aa358b7ada53d724a10782f
+PODFILE CHECKSUM: 844a24e9f56590b5db1ec1ad331b58d90dfedadb
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - DZNEmptyDataSet (1.8.1)
   - HNScraper (0.2.2)
-  - Kingfisher (4.8.1)
+  - Kingfisher (4.10.1)
   - libHN (4.1.0)
   - PromiseKit (4.5.2):
     - PromiseKit/Foundation (= 4.5.2)
@@ -14,7 +14,7 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (4.5.2):
     - PromiseKit/CorePromise
-  - SkeletonView (1.1.1)
+  - SkeletonView (1.4.1)
 
 DEPENDENCIES:
   - DZNEmptyDataSet
@@ -45,11 +45,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
   HNScraper: 89d135811bc8b9088adbb677c0bbc6cf8ed85cc0
-  Kingfisher: 868c1149679a7ab6869be118faa9b5aed154aaf0
+  Kingfisher: c148cd7b47ebde9989f6bc7c27dcaa79d81279a0
   libHN: fe671e9d39466235239b793f1f0181baadb327b2
   PromiseKit: 743e497a5f505a470d3bbbf4ce0663c1268af0a4
-  SkeletonView: 041053e904504e7d8db83df166e599be75659fe1
+  SkeletonView: 60d6ce7edb0cb4c7758db33c74add50392b3c475
 
-PODFILE CHECKSUM: 844a24e9f56590b5db1ec1ad331b58d90dfedadb
+PODFILE CHECKSUM: 528ca53b92f8890ad2f5712789d86c3c46cc0e7b
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,6 @@ PODS:
   - DZNEmptyDataSet (1.8.1)
   - HNScraper (0.2.2)
   - Kingfisher (4.10.1)
-  - libHN (4.1.0)
   - PromiseKit (4.5.2):
     - PromiseKit/Foundation (= 4.5.2)
     - PromiseKit/QuartzCore (= 4.5.2)
@@ -20,7 +19,6 @@ DEPENDENCIES:
   - DZNEmptyDataSet
   - HNScraper
   - Kingfisher
-  - libHN (from `https://github.com/weiran/libHN`, commit `6759f4ac591f5f36b01158260627ba0bf36eddc1`)
   - PromiseKit (~> 4.x)
   - SkeletonView
 
@@ -32,24 +30,13 @@ SPEC REPOS:
     - PromiseKit
     - SkeletonView
 
-EXTERNAL SOURCES:
-  libHN:
-    :commit: 6759f4ac591f5f36b01158260627ba0bf36eddc1
-    :git: https://github.com/weiran/libHN
-
-CHECKOUT OPTIONS:
-  libHN:
-    :commit: 6759f4ac591f5f36b01158260627ba0bf36eddc1
-    :git: https://github.com/weiran/libHN
-
 SPEC CHECKSUMS:
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
   HNScraper: 89d135811bc8b9088adbb677c0bbc6cf8ed85cc0
   Kingfisher: c148cd7b47ebde9989f6bc7c27dcaa79d81279a0
-  libHN: fe671e9d39466235239b793f1f0181baadb327b2
   PromiseKit: 743e497a5f505a470d3bbbf4ce0663c1268af0a4
   SkeletonView: 60d6ce7edb0cb4c7758db33c74add50392b3c475
 
-PODFILE CHECKSUM: 528ca53b92f8890ad2f5712789d86c3c46cc0e7b
+PODFILE CHECKSUM: e10813922852ca5d7db1459262dc07413462b789
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Switched to using [HNScraper](https://github.com/tsucres/HNScraper), which is a Swift rewrite of [libHN](https://github.com/bennyguitar/libHN). I will leave this PR open for a few weeks to test the stability.