### PR TITLE
Highlight the points of popular posts

### DIFF
--- a/Client/PostTitleView.swift
+++ b/Client/PostTitleView.swift
@@ -18,6 +18,8 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
     @IBOutlet var metadataLabel: UILabel!
     
     var isTitleTapEnabled = false
+    var pointsMetadataRangeToHighlight: NSRange?
+    var popularPostPointsThreshold = 200
     
     var delegate: PostTitleViewDelegate?
     
@@ -26,6 +28,7 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
             guard let post = post else { return }
             titleLabel.text = post.title
             metadataLabel.attributedText = metadataText(for: post)
+            highlightPointsInMetadata()
         }
     }
     
@@ -68,6 +71,13 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
         
         string.append(NSAttributedString(string: "\(post.points)"))
         string.append(pointsIconAttributedString)
+
+        if (post.points > popularPostPointsThreshold) {
+            pointsMetadataRangeToHighlight = NSRange(location: 0, length: string.length)
+        } else {
+            pointsMetadataRangeToHighlight = nil
+        }
+
         string.append(NSAttributedString(string: "• \(post.commentCount)"))
         string.append(commentsIconAttributedString)
         string.append(NSAttributedString(string: " • \(domainLabelText(for: post))"))
@@ -88,11 +98,25 @@ class PostTitleView: UIView, UIGestureRecognizerDelegate {
         attachment.bounds = CGRect(x: 0, y: -2, width: image.size.width, height: image.size.height)
         return attachment
     }
+
+    private func highlightPointsInMetadata() {
+        guard let mutableMetadataText = metadataLabel.attributedText?.mutableCopy() as? NSMutableAttributedString else {
+            return
+        }
+        if let range = pointsMetadataRangeToHighlight {
+            mutableMetadataText.addAttribute(
+                NSAttributedString.Key.foregroundColor,
+                value: UIColor.orange,
+                range: range)
+            metadataLabel.attributedText = mutableMetadataText
+        }
+    }
 }
 
 extension PostTitleView: Themed {
     func applyTheme(_ theme: AppTheme) {
         titleLabel.textColor = theme.titleTextColor
         metadataLabel.textColor = theme.textColor
+        highlightPointsInMetadata()
     }
 }


### PR DESCRIPTION
Hey there, not sure if this is a PR you're keen to accept, but it highlights the points of popular posts in orange. Useful for quickly skimming the list and seeing what's receiving the most attention.

<img width="602" alt="screen shot 2019-02-03 at 12 06 11 pm" src="https://user-images.githubusercontent.com/1853337/52171176-47902d00-27ac-11e9-8a35-dda049275e3c.png">

Currently the threshold is set at 200 points (chosen pretty unscientifically), which usually captures 4-5 posts from the front page.

Also thanks for making this app open source! Definitely the best HN client I've found on the App Store.