### PR TITLE
Added long press functionality for url in comment

### DIFF
--- a/Client/Comments/CommentTableViewCell.swift
+++ b/Client/Comments/CommentTableViewCell.swift
@@ -72,12 +72,19 @@ class CommentTableViewCell : SwipeTableViewCell {
 }
 
 extension CommentTableViewCell: UITextViewDelegate {
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
-        if let commentDelegate = commentDelegate {
-            commentDelegate.linkTapped(URL, sender: textView)
-            return false
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        switch interaction {
+            //This is the case when user just taps on the link
+        case .invokeDefaultAction:
+            if let commentDelegate = commentDelegate {
+                commentDelegate.linkTapped(URL, sender: textView)
+                return false
+            }
+            return true
+        default:
+            // default case will handle presentActions (Long Press) case on url
+            return true
         }
-        return true
     }
 }
 


### PR DESCRIPTION
#### Reference To Issue 
[Issue # 67](https://github.com/weiran/Hackers/issues/67)

#### Description 
- I am using this `textView(_:shouldInteractWith:in:interaction:)` delegate method to detect long press on url. 
- Handled tap case separately and left other cases in default case.
- Tested the result and its working great.

@weiran Kindly have a look at this PR. 