### PR TITLE
Tapping a job in jobs section will open URL directly without showing comments

### DIFF
--- a/Client/Main.storyboard
+++ b/Client/Main.storyboard
@@ -93,7 +93,6 @@
                                 <connections>
                                     <outlet property="postTitleView" destination="fNt-dt-R2Y" id="Xg6-38-hok"/>
                                     <outlet property="thumbnailImageView" destination="OFG-KR-Pd0" id="i8s-bN-Xew"/>
-                                    <segue destination="PXZ-r3-pvU" kind="showDetail" identifier="ShowComments" id="Tz8-FP-fhl"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -212,7 +211,7 @@
         <!--Empty Data Set Delegate-->
         <scene sceneID="xDu-IX-6YL">
             <objects>
-                <tableViewController id="evu-Yh-MGy" customClass="CommentsViewController" customModule="Hackers" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="CommentsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="evu-Yh-MGy" customClass="CommentsViewController" customModule="Hackers" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="60" sectionFooterHeight="18" id="TkO-Pr-orw">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Client/Posts List/NewsViewController.swift
+++ b/Client/Posts List/NewsViewController.swift
@@ -41,15 +41,12 @@ class NewsViewController : UITableViewController {
         }
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "ShowComments" {
-            if let indexPath = tableView.indexPathForSelectedRow,
-                let segueNavigationController = segue.destination as? UINavigationController,
-                let commentsViewController = segueNavigationController.topViewController as? CommentsViewController {
-                let post = posts?[indexPath.row]
-                commentsViewController.post = post
-                commentsViewController.hidesBottomBarWhenPushed = true
-            }
+    func navigateToComments(for post : HNPost) {
+        if let commentsViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CommentsViewController") as? CommentsViewController {
+            commentsViewController.post = post
+            commentsViewController.hidesBottomBarWhenPushed = true
+            let appNavigationController = AppNavigationController(rootViewController: commentsViewController)
+            self.navigationController?.pushViewController(appNavigationController, animated: true)
         }
     }
 }
@@ -110,6 +107,15 @@ extension NewsViewController {
     override open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let posts = posts, indexPath.row == posts.count - 5 {
             loadMorePosts()
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let post = posts?[indexPath.row] else { return }
+        if postType == .jobs {
+            didPressLinkButton(post)
+        } else {
+            navigateToComments(for: post)
         }
     }
 }
@@ -188,7 +194,7 @@ extension NewsViewController: UIViewControllerPreviewingDelegate, SFSafariViewCo
         let viewCommentsPreviewAction = UIPreviewAction(title: commentsPreviewActionTitle, style: .default) {
             [unowned self, indexPath = indexPath] (action, viewController) -> Void in
             self.tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
-            self.performSegue(withIdentifier: "ShowComments", sender: nil)
+            self.navigateToComments(for: post)
         }
         return [viewCommentsPreviewAction]
     }


### PR DESCRIPTION
#### Reference To Issue 
[Issue#71](https://github.com/weiran/Hackers/issues/71)

#### Description 
- I have removed the segue from `postCell` to `commentsController` and did this job programmatically by pushing `AppNavigationController` with `CommentsController` as a root controller.
- I also used the same code to push `CommentsController` in case of `UIPreviewActionSheet` and its working perfectly.
- I used `didPressLinkButton` method to open job directly.
- I have tested all the scenarios for `PostCell` whether it is thumbnail tap or swipe all are working.

@weiran Kindly have a look at this PR. 