### PR TITLE
Hid the tab bar for comments viewcontroller

### DIFF
--- a/Client/Comments/CommentsViewController.swift
+++ b/Client/Comments/CommentsViewController.swift
@@ -46,6 +46,8 @@ class CommentsViewController : UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupHandoff(with: post, activityType: .comments)
+        self.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.layer.zPosition = -1
     }
     
     deinit {

--- a/Client/Posts List/NewsViewController.swift
+++ b/Client/Posts List/NewsViewController.swift
@@ -39,6 +39,8 @@ class NewsViewController : UITableViewController {
         if UIScreen.main.traitCollection.horizontalSizeClass == .compact {
             self.smoothlyDeselectRows()
         }
+        self.tabBarController?.tabBar.layer.zPosition = 0
+        self.tabBarController?.tabBar.isHidden = false
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
#### Reference To Issue 
[Issue#70](https://github.com/weiran/Hackers/issues/70)

#### Description 
- I am hiding the tab bar whenever the CommentsViewController appears and unhides it every time it pops.
- Tested all cases and its working.

@weiran you can check it out.