### PR TITLE
Add setting to enable/disable swipe actions

### DIFF
--- a/App/Comments/CommentsViewController.swift
+++ b/App/Comments/CommentsViewController.swift
@@ -215,6 +215,11 @@ extension CommentsViewController: SwipeTableViewCellDelegate {
                    editActionsForRowAt indexPath: IndexPath,
                    for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         guard let post = self.post else { return nil }
+
+        if !UserDefaults.standard.swipeActionsEnabled {
+            return nil
+        }
+
         switch (orientation, indexPath.section) {
         case (.left, 0):
             return swipeCellKitActions?.voteAction(post: post, tableView: tableView,

--- a/App/Feed/FeedCollectionViewController.swift
+++ b/App/Feed/FeedCollectionViewController.swift
@@ -26,6 +26,7 @@ class FeedCollectionViewController: UIViewController {
         super.viewDidLoad()
 
         setupCollectionView()
+        setupCollectionViewListConfiguration()
         setupTitle()
         setupNotificationCenter()
         showOnboarding()
@@ -67,6 +68,7 @@ class FeedCollectionViewController: UIViewController {
     }
 
     @objc private func fetchFeedWithReset() {
+        setupCollectionViewListConfiguration()
         viewModel.reset()
         fetchFeed()
     }
@@ -93,11 +95,21 @@ class FeedCollectionViewController: UIViewController {
 }
 
 extension FeedCollectionViewController: UICollectionViewDelegate {
-    private func setupCollectionView() {
+
+    private func setupCollectionViewListConfiguration() {
         var config = UICollectionLayoutListConfiguration(appearance: .plain)
-        config.leadingSwipeActionsConfigurationProvider = voteSwipeActionConfiguration(indexPath:)
+
+        if UserDefaults.standard.swipeActionsEnabled {
+            config.leadingSwipeActionsConfigurationProvider = voteSwipeActionConfiguration(indexPath:)
+        }
+
         config.showsSeparators = false
 
+        let layout = UICollectionViewCompositionalLayout.list(using: config)
+        collectionView.setCollectionViewLayout(layout, animated: false)
+    }
+
+    private func setupCollectionView() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(
             self,
@@ -113,8 +125,6 @@ extension FeedCollectionViewController: UICollectionViewDelegate {
             forCellWithReuseIdentifier: cellIdentifier
         )
 
-        let layout = UICollectionViewCompositionalLayout.list(using: config)
-        collectionView.setCollectionViewLayout(layout, animated: false)
         collectionView.dataSource = dataSource
     }
 

--- a/App/Main.storyboard
+++ b/App/Main.storyboard
@@ -513,6 +513,39 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Functionality" id="vAy-w9-rUW" userLabel="Functionality">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="ila-G7-nJ9" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="501" width="343" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ila-G7-nJ9" id="pfP-AY-HJQ">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swipe Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MXF-rP-Tah">
+                                                    <rect key="frame" x="16" y="11.5" width="92" height="21"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VQH-5Z-1Ir">
+                                                    <rect key="frame" x="279" y="6.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="swipeActionsValueChanged:" destination="uZL-eS-tCe" eventType="valueChanged" id="Dyc-Eg-Fs0"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="MXF-rP-Tah" firstAttribute="leading" secondItem="pfP-AY-HJQ" secondAttribute="leadingMargin" id="DCj-cb-Vdg"/>
+                                                <constraint firstAttribute="trailing" secondItem="VQH-5Z-1Ir" secondAttribute="trailing" constant="15" id="VBc-kH-7VP"/>
+                                                <constraint firstItem="VQH-5Z-1Ir" firstAttribute="centerY" secondItem="pfP-AY-HJQ" secondAttribute="centerY" id="vD9-Ir-u0w"/>
+                                                <constraint firstItem="MXF-rP-Tah" firstAttribute="centerY" secondItem="pfP-AY-HJQ" secondAttribute="centerY" id="vy4-6E-zCq"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Reading" id="1AH-ih-fLT">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="by2-0S-CnW" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
@@ -597,6 +630,7 @@
                         <outlet property="openInDefaultBrowserSwitch" destination="g4G-LF-pRI" id="M9B-7A-i52"/>
                         <outlet property="safariReaderModeSwitch" destination="cmY-8P-GUK" id="6fh-TZ-GYa"/>
                         <outlet property="showThumbnailsSwitch" destination="5xy-Xy-ER7" id="DeA-4x-iv7"/>
+                        <outlet property="swipeActionsSwitch" destination="VQH-5Z-1Ir" id="hl6-Y0-Z63"/>
                         <outlet property="usernameLabel" destination="PDK-aN-wRW" id="lDn-Zb-2N1"/>
                         <outlet property="versionLabel" destination="vai-hd-k76" id="t8A-MH-SCD"/>
                     </connections>

--- a/App/Settings/SettingsViewController.swift
+++ b/App/Settings/SettingsViewController.swift
@@ -19,6 +19,7 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var accountLabel: UILabel!
     @IBOutlet weak var usernameLabel: UILabel!
     @IBOutlet weak var showThumbnailsSwitch: UISwitch!
+    @IBOutlet weak var swipeActionsSwitch: UISwitch!
     @IBOutlet weak var safariReaderModeSwitch: UISwitch!
     @IBOutlet weak var openInDefaultBrowserSwitch: UISwitch!
     @IBOutlet weak var openInDefaultBrowserLabel: UILabel!
@@ -30,6 +31,7 @@ class SettingsViewController: UITableViewController {
         super.viewDidLoad()
         safariReaderModeSwitch.isOn = UserDefaults.standard.safariReaderModeEnabled
         showThumbnailsSwitch.isOn = UserDefaults.standard.showThumbnails
+        swipeActionsSwitch.isOn = UserDefaults.standard.swipeActionsEnabled
         updateOpenInDefaultBrowser()
         updateUsername()
         updateVersion()
@@ -60,6 +62,11 @@ class SettingsViewController: UITableViewController {
 
     @IBAction func showThumbnailsValueChanged(_ sender: UISwitch) {
         UserDefaults.standard.setShowThumbnails(sender.isOn)
+        NotificationCenter.default.post(name: Notification.Name.refreshRequired, object: nil)
+    }
+
+    @IBAction func swipeActionsValueChanged(_ sender: UISwitch) {
+        UserDefaults.standard.setSwipeActions(sender.isOn)
         NotificationCenter.default.post(name: Notification.Name.refreshRequired, object: nil)
     }
 

--- a/App/Settings/UserDefaultsExtensions.swift
+++ b/App/Settings/UserDefaultsExtensions.swift
@@ -45,6 +45,15 @@ extension UserDefaults {
         set(enabled, forKey: UserDefaultsKeys.safariReaderMode.rawValue)
     }
 
+    var swipeActionsEnabled: Bool {
+        let swipeActionsSetting = bool(forKey: UserDefaultsKeys.swipeActions.rawValue)
+        return swipeActionsSetting
+    }
+
+    func setSwipeActions(_ enabled: Bool) {
+        set(enabled, forKey: UserDefaultsKeys.swipeActions.rawValue)
+    }
+
     var openInDefaultBrowser: Bool {
         let openInDefaultBrowser = bool(forKey: UserDefaultsKeys.openInDefaultBrowser.rawValue)
         return openInDefaultBrowser
@@ -59,6 +68,7 @@ extension UserDefaults {
             UserDefaultsKeys.theme.rawValue: "light",
             UserDefaultsKeys.systemTheme.rawValue: true,
             UserDefaultsKeys.showThumbnails.rawValue: true,
+            UserDefaultsKeys.swipeActions.rawValue: true,
             UserDefaultsKeys.safariReaderMode.rawValue: false,
             UserDefaultsKeys.openInDefaultBrowser.rawValue: false
         ])
@@ -71,4 +81,5 @@ enum UserDefaultsKeys: String {
     case safariReaderMode
     case openInDefaultBrowser
     case showThumbnails
+    case swipeActions
 }


### PR DESCRIPTION
First of all - love the app, great work! I use it basically every day and its awesome that its open source too to modify.

Had a few issues with swipe actions accidentally upvoting comments and posts for me when using the app. This PR adds a item on the settings page to enable/disable these actions on my fork that I side load myself, don't know wether its useful to you to merge.

I'm not a huge swift/iOS expert (first PR) so feel free if you want to merge the PR to suggest some changes and I'll do them.