### PR TITLE
Fix duplicates in feed and next page fetching for "New" and "Jobs" posts

### DIFF
--- a/App/Feed/FeedViewModel.swift
+++ b/App/Feed/FeedViewModel.swift
@@ -14,6 +14,7 @@ class FeedViewModel {
     var postIds: Set<Int> = Set()
     var postType: PostType = .news
     var pageIndex = 1
+    var lastPostId = 0
     var isFetching = false
 
     func fetchFeed(fetchNextPage: Bool = false) -> Promise<Void> {
@@ -22,13 +23,17 @@ class FeedViewModel {
         }
 
         if fetchNextPage {
-            pageIndex += 1
+            if postType == .newest || postType == .jobs {
+                lastPostId = posts.last?.id ?? lastPostId
+            } else {
+                pageIndex += 1
+            }
         }
 
         isFetching = true
 
         return firstly {
-            HackersKit.shared.getPosts(type: postType, page: pageIndex)
+            HackersKit.shared.getPosts(type: postType, page: pageIndex, nextId: lastPostId)
         }.done { posts in
             let newPosts = posts.filter { !self.postIds.contains($0.id) }
             let newPostIds = newPosts.map { $0.id }
@@ -42,6 +47,7 @@ class FeedViewModel {
         posts = []
         postIds = Set()
         pageIndex = 1
+        lastPostId = 0
         isFetching = false
     }
 

--- a/App/Feed/FeedViewModel.swift
+++ b/App/Feed/FeedViewModel.swift
@@ -11,6 +11,7 @@ import PromiseKit
 
 class FeedViewModel {
     var posts: [Post] = []
+    var postIds: Set<Int> = Set()
     var postType: PostType = .news
     var pageIndex = 1
     var isFetching = false
@@ -29,13 +30,17 @@ class FeedViewModel {
         return firstly {
             HackersKit.shared.getPosts(type: postType, page: pageIndex)
         }.done { posts in
-            self.posts.append(contentsOf: posts)
+            let newPosts = posts.filter { !self.postIds.contains($0.id) }
+            let newPostIds = newPosts.map { $0.id }
+            self.posts.append(contentsOf: newPosts)
+            self.postIds.formUnion(newPostIds)
             self.isFetching = false
         }
     }
 
     func reset() {
         posts = []
+        postIds = Set()
         pageIndex = 1
         isFetching = false
     }

--- a/Shared Frameworks/HackersKit/HackersKit+PostsList.swift
+++ b/Shared Frameworks/HackersKit/HackersKit+PostsList.swift
@@ -11,9 +11,9 @@ import PromiseKit
 import SwiftSoup
 
 extension HackersKit {
-    func getPosts(type: PostType, page: Int = 1) -> Promise<[Post]> {
+    func getPosts(type: PostType, page: Int = 1, nextId: Int = 0) -> Promise<[Post]> {
         firstly {
-            fetchPostsHtml(type: type, page: page)
+            fetchPostsHtml(type: type, page: page, nextId: nextId)
         }.map { html in
             try HtmlParser.postsTableElement(from: html)
         }.compactMap { tableElement in
@@ -21,8 +21,13 @@ extension HackersKit {
         }
     }
 
-    private func fetchPostsHtml(type: PostType, page: Int) -> Promise<String> {
-        let url = URL(string: "https://news.ycombinator.com/\(type.rawValue)?p=\(page)")!
+    private func fetchPostsHtml(type: PostType, page: Int, nextId: Int) -> Promise<String> {
+        var url: URL
+        if type == .newest || type == .jobs {
+            url = URL(string: "https://news.ycombinator.com/\(type.rawValue)?next=\(nextId)")!
+        } else {
+            url = URL(string: "https://news.ycombinator.com/\(type.rawValue)?p=\(page)")!
+        }
         return fetchHtml(url: url)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/weiran/Hackers/issues/194 and https://github.com/weiran/Hackers/issues/54

- Duplicate posts may show up in the feed when you scroll to load next posts (this happens when post ranking changes in between).
- Currently if you scroll through "New" or "Jobs" posts, it reloads the same set of posts over and over again because their API uses post IDs instead of page numbers.

Let me know if I should change anything - I'm pretty new to Swift.

I really love the app!