### PR TITLE
[CI] update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: macos-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7.3'
     - name: Run SwiftLint
-      uses: maierj/fastlane-action@v2.0.1
+      uses: maierj/fastlane-action@v2.2.0
       with: 
         lane: 'lint'
         subdirectory: 'fastlane'
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7.3'
@@ -33,7 +33,7 @@ jobs:
     - name: Install Dependencies
       run: pod install --repo-update
     - name: Run UI Tests
-      uses: maierj/fastlane-action@v2.0.1
+      uses: maierj/fastlane-action@v2.2.0
       with: 
         lane: 'test'
         subdirectory: 'fastlane'
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7.3'
@@ -50,7 +50,7 @@ jobs:
     - name: Install Dependencies
       run: pod install --repo-update
     - name: Build
-      uses: maierj/fastlane-action@v2.0.1
+      uses: maierj/fastlane-action@v2.2.0
       with: 
         lane: 'build'
         subdirectory: 'fastlane'


### PR DESCRIPTION
Bump GitHub Actions to their latest versions. 
Main change for actions/checkout is it's now using Node 16 instead of 12, 12 is EOL at the end of this month.