### PR TITLE
Remove URL from title and SwiftLint from homebrew for apple silicon

### DIFF
--- a/Hackers.xcodeproj/project.pbxproj
+++ b/Hackers.xcodeproj/project.pbxproj
@@ -810,7 +810,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n  \"swiftlint\"\nelse\n  echo \"Skipping the script because of preview mode\"\nfi\n";
+			shellScript = "if [ $ENABLE_PREVIEWS == \"NO\" ]\nthen\n  export PATH=\"$PATH:/opt/homebrew/bin\"\n  if which swiftlint > /dev/null; then\n    swiftlint\n  else\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n  fi\nelse\n  echo \"Skipping the script because of preview mode\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Shared Frameworks/HackersKit/HtmlParser.swift
+++ b/Shared Frameworks/HackersKit/HtmlParser.swift
@@ -43,7 +43,7 @@ enum HtmlParser {
             throw Exception.Error(type: .SelectorParseException, Message: "Couldn't parse post ID")
         }
         let urlString = try postElement.select(".titleline").select("a").attr("href")
-        let title = try postElement.select(".titleline").select("a").text()
+        let title = try postElement.select(".titleline").select("a").first()!.text()
         guard let url = URL(string: urlString) else {
             throw Exception.Error(type: .SelectorParseException, Message: "Couldn't parse post URL")
         }


### PR DESCRIPTION
Hi! I really enjoy reading HN with your app and would like to propose a few fixes. The first one: `title` variable should not contain URL. I double-checked the app in simulator, now titles are correct . The second fix: I use Apple Silicon machine and I had to fix SwiftLint sh script as described in [https://github.com/realm/SwiftLint#xcode](url). Hope that helps!