### PR TITLE
Copy and select text menu items

### DIFF
--- a/App/Comments/CommentTableViewCell.swift
+++ b/App/Comments/CommentTableViewCell.swift
@@ -70,7 +70,7 @@ class CommentTableViewCell: SwipeTableViewCell {
         if let commentTextView = commentTextView, comment.visibility == .visible {
             // only for expanded comments
             let commentFont = UIFont.preferredFont(forTextStyle: .subheadline)
-            let commentAttributedString = parseToAttributedString(comment.text)
+            let commentAttributedString = comment.text.parseToAttributedString()
             let commentRange = NSRange(location: 0, length: commentAttributedString.length)
 
             commentAttributedString.addAttribute(NSAttributedString.Key.font,
@@ -82,20 +82,6 @@ class CommentTableViewCell: SwipeTableViewCell {
 
             commentTextView.attributedText = commentAttributedString
         }
-    }
-
-    private func parseToAttributedString(_ html: String) -> NSMutableAttributedString {
-        let paragraphIdentifier = "PARAGRAPH_NEED_NEW_LINES_HERE"
-
-        // swiftlint:disable unused_optional_binding
-        guard let document = try? SwiftSoup.parse(html),
-            let _ = try? document.select("p").before(paragraphIdentifier),
-            let text = try? document.text() else {
-            return NSMutableAttributedString()
-        }
-        // swiftlint:enable unused_optional_binding
-
-        return NSMutableAttributedString(string: text.replacingOccurrences(of: paragraphIdentifier + " ", with: "\n\n"))
     }
 }
 

--- a/App/Comments/CommentsViewController.swift
+++ b/App/Comments/CommentsViewController.swift
@@ -267,10 +267,26 @@ extension CommentsViewController {
                 self?.shareComment(at: indexPath)
             }
 
+			let copy = UIAction(
+				title: "Copy",
+				image: UIImage(systemName: "doc.on.doc"),
+				identifier: UIAction.Identifier(rawValue: "copy.comment")
+			) { [weak self] _ in
+				self?.copyComment(at: indexPath)
+			}
+
+			let selectText = UIAction(
+				title: "Select Text",
+				image: UIImage(systemName: "selection.pin.in.out"),
+				identifier: UIAction.Identifier(rawValue: "select.comment")
+			) { [weak self] _ in
+				self?.selectCommentText(at: indexPath)
+			}
+
             let voteMenu = upvoted ? unvote : upvote
             let shareMenu = UIMenu(title: "", options: .displayInline, children: [share])
 
-            return UIMenu(title: "", image: nil, identifier: nil, children: [voteMenu, shareMenu])
+            return UIMenu(title: "", image: nil, identifier: nil, children: [voteMenu, copy, selectText, shareMenu])
         }
     }
 
@@ -396,6 +412,17 @@ extension CommentsViewController: SwipeTableViewCellDelegate {
         activityViewController.popoverPresentationController?.sourceView = cell
         self.present(activityViewController, animated: true, completion: nil)
     }
+	
+	private func selectCommentText(at indexPath: IndexPath) {
+		let comment = self.commentsController.visibleComments[indexPath.row]
+		performSegue(withIdentifier: "ShowTextSelectionSegue", sender: comment.text)
+	}
+	
+	private func copyComment(at indexPath: IndexPath) {
+		let comment = self.commentsController.visibleComments[indexPath.row]
+		let pasteboard = UIPasteboard.general
+		pasteboard.string = comment.text.parseToAttributedString().string
+	}
 
     private func collapseAction() -> SwipeAction {
         let collapseAction = SwipeAction(style: .default, title: "Collapse") { _, indexPath in
@@ -516,4 +543,15 @@ extension CommentsViewController {
     private func tearDownHandoff() {
         userActivity?.invalidate()
     }
+}
+
+extension CommentsViewController {
+	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+		if let comment = sender as? String,
+		   segue.identifier == "ShowTextSelectionSegue",
+		   let navVC = segue.destination as? UINavigationController,
+		   let textSelectionViewController = navVC.children.first as? TextSelectionViewController {
+			textSelectionViewController.comment = comment
+		}
+	}
 }

--- a/App/Comments/CommentsViewController.swift
+++ b/App/Comments/CommentsViewController.swift
@@ -267,21 +267,21 @@ extension CommentsViewController {
                 self?.shareComment(at: indexPath)
             }
 
-			let copy = UIAction(
-				title: "Copy",
-				image: UIImage(systemName: "doc.on.doc"),
-				identifier: UIAction.Identifier(rawValue: "copy.comment")
-			) { [weak self] _ in
-				self?.copyComment(at: indexPath)
-			}
+            let copy = UIAction(
+                title: "Copy",
+                image: UIImage(systemName: "doc.on.doc"),
+                identifier: UIAction.Identifier(rawValue: "copy.comment")
+            ) { [weak self] _ in
+                self?.copyComment(at: indexPath)
+            }
 
-			let selectText = UIAction(
-				title: "Select Text",
-				image: UIImage(systemName: "selection.pin.in.out"),
-				identifier: UIAction.Identifier(rawValue: "select.comment")
-			) { [weak self] _ in
-				self?.selectCommentText(at: indexPath)
-			}
+            let selectText = UIAction(
+                title: "Select Text",
+                image: UIImage(systemName: "selection.pin.in.out"),
+                identifier: UIAction.Identifier(rawValue: "select.comment")
+            ) { [weak self] _ in
+                self?.selectCommentText(at: indexPath)
+            }
 
             let voteMenu = upvoted ? unvote : upvote
             let shareMenu = UIMenu(title: "", options: .displayInline, children: [share])
@@ -412,18 +412,18 @@ extension CommentsViewController: SwipeTableViewCellDelegate {
         activityViewController.popoverPresentationController?.sourceView = cell
         self.present(activityViewController, animated: true, completion: nil)
     }
-	
-	private func selectCommentText(at indexPath: IndexPath) {
-		let comment = self.commentsController.visibleComments[indexPath.row]
-		performSegue(withIdentifier: "ShowTextSelectionSegue", sender: comment.text)
-	}
-	
-	private func copyComment(at indexPath: IndexPath) {
-		let comment = self.commentsController.visibleComments[indexPath.row]
-		let pasteboard = UIPasteboard.general
-		pasteboard.string = comment.text.parseToAttributedString().string
-	}
 
+    private func selectCommentText(at indexPath: IndexPath) {
+        let comment = self.commentsController.visibleComments[indexPath.row]
+        performSegue(withIdentifier: "ShowTextSelectionSegue", sender: comment.text)
+    }
+    
+    private func copyComment(at indexPath: IndexPath) {
+        let comment = self.commentsController.visibleComments[indexPath.row]
+        let pasteboard = UIPasteboard.general
+        pasteboard.string = comment.text.parseToAttributedString().string
+    }
+    
     private func collapseAction() -> SwipeAction {
         let collapseAction = SwipeAction(style: .default, title: "Collapse") { _, indexPath in
             let comment = self.commentsController.visibleComments[indexPath.row]
@@ -546,12 +546,12 @@ extension CommentsViewController {
 }
 
 extension CommentsViewController {
-	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-		if let comment = sender as? String,
-		   segue.identifier == "ShowTextSelectionSegue",
-		   let navVC = segue.destination as? UINavigationController,
-		   let textSelectionViewController = navVC.children.first as? TextSelectionViewController {
-			textSelectionViewController.comment = comment
-		}
-	}
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if let comment = sender as? String,
+           segue.identifier == "ShowTextSelectionSegue",
+           let navVC = segue.destination as? UINavigationController,
+           let textSelectionViewController = navVC.children.first as? TextSelectionViewController {
+            textSelectionViewController.comment = comment
+        }
+    }
 }

--- a/App/Comments/TextSelectionViewController.swift
+++ b/App/Comments/TextSelectionViewController.swift
@@ -9,39 +9,39 @@
 import UIKit
 
 final class TextSelectionViewController: UIViewController {
-
-	var comment: String?
-
-	@IBOutlet private var commentTextView: UITextView!
-
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		setup()
-	}
-
-	private func setup() {
-		view.backgroundColor = AppTheme.default.backgroundColor
-		setupCommentTextView()
-	}
-
-	private func setupCommentTextView() {
-		commentTextView.attributedText = attributedComment()
-		commentTextView.textContainerInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-		commentTextView.textColor = AppTheme.default.textColor
-		commentTextView.selectAll(nil)
-	}
-	
-	private func attributedComment() -> NSAttributedString? {
-		   guard let comment = comment else { return nil }
-		   
-		   let commentFont = UIFont.preferredFont(forTextStyle: .body)
-		   let attributes: [NSAttributedString.Key: Any] = [.font: commentFont]
-		   let attributedString = NSAttributedString(string: comment, attributes: attributes)
-		   
-		   return attributedString
-	   }
-
-	@IBAction private func didPressDone(_ sender: Any) {
-		dismiss(animated: true)
-	}
+    
+    var comment: String?
+    
+    @IBOutlet private var commentTextView: UITextView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+    
+    private func setup() {
+        view.backgroundColor = AppTheme.default.backgroundColor
+        setupCommentTextView()
+    }
+    
+    private func setupCommentTextView() {
+        commentTextView.attributedText = attributedComment()
+        commentTextView.textContainerInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        commentTextView.textColor = AppTheme.default.textColor
+        commentTextView.selectAll(nil)
+    }
+    
+    private func attributedComment() -> NSAttributedString? {
+        guard let comment = comment else { return nil }
+        
+        let commentFont = UIFont.preferredFont(forTextStyle: .body)
+        let attributes: [NSAttributedString.Key: Any] = [.font: commentFont]
+        let attributedString = NSAttributedString(string: comment, attributes: attributes)
+        
+        return attributedString
+    }
+    
+    @IBAction private func didPressDone(_ sender: Any) {
+        dismiss(animated: true)
+    }
 }

--- a/App/Comments/TextSelectionViewController.swift
+++ b/App/Comments/TextSelectionViewController.swift
@@ -1,0 +1,47 @@
+//
+//  TextSelectionViewController.swift
+//  Hackers
+//
+//  Created by Peter Ajayi on 08/07/2023.
+//  Copyright © 2023 Glass Umbrella. All rights reserved.
+//
+
+import UIKit
+
+final class TextSelectionViewController: UIViewController {
+
+	var comment: String?
+
+	@IBOutlet private var commentTextView: UITextView!
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		setup()
+	}
+
+	private func setup() {
+		view.backgroundColor = AppTheme.default.backgroundColor
+		setupCommentTextView()
+	}
+
+	private func setupCommentTextView() {
+		commentTextView.attributedText = attributedComment()
+		commentTextView.textContainerInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+		commentTextView.textColor = AppTheme.default.textColor
+		commentTextView.selectAll(nil)
+	}
+	
+	private func attributedComment() -> NSAttributedString? {
+		   guard let comment = comment else { return nil }
+		   
+		   let commentFont = UIFont.preferredFont(forTextStyle: .body)
+		   let attributes: [NSAttributedString.Key: Any] = [.font: commentFont]
+		   let attributedString = NSAttributedString(string: comment, attributes: attributes)
+		   
+		   return attributedString
+	   }
+
+	@IBAction private func didPressDone(_ sender: Any) {
+		dismiss(animated: true)
+	}
+}

--- a/App/Extensions/StringExtensions.swift
+++ b/App/Extensions/StringExtensions.swift
@@ -23,16 +23,16 @@ extension String {
     }
 
     func parseToAttributedString() -> NSMutableAttributedString {
-		let paragraphIdentifier = "PARAGRAPH_NEED_NEW_LINES_HERE"
-
-		// swiftlint:disable unused_optional_binding
-		guard let document = try? SwiftSoup.parse(self),
-			let _ = try? document.select("p").before(paragraphIdentifier),
-			let text = try? document.text() else {
-			return NSMutableAttributedString()
-		}
-		// swiftlint:enable unused_optional_binding
-
-		return NSMutableAttributedString(string: text.replacingOccurrences(of: paragraphIdentifier + " ", with: "\n\n"))
-	}
+        let paragraphIdentifier = "PARAGRAPH_NEED_NEW_LINES_HERE"
+        
+        // swiftlint:disable unused_optional_binding
+        guard let document = try? SwiftSoup.parse(self),
+              let _ = try? document.select("p").before(paragraphIdentifier),
+              let text = try? document.text() else {
+            return NSMutableAttributedString()
+        }
+        // swiftlint:enable unused_optional_binding
+        
+        return NSMutableAttributedString(string: text.replacingOccurrences(of: paragraphIdentifier + " ", with: "\n\n"))
+    }
 }

--- a/App/Extensions/StringExtensions.swift
+++ b/App/Extensions/StringExtensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftSoup
 
 extension String {
     subscript(value: PartialRangeUpTo<Int>) -> Substring {
@@ -20,4 +21,18 @@ extension String {
     subscript(value: PartialRangeFrom<Int>) -> Substring {
         return self[index(startIndex, offsetBy: value.lowerBound)...]
     }
+
+    func parseToAttributedString() -> NSMutableAttributedString {
+		let paragraphIdentifier = "PARAGRAPH_NEED_NEW_LINES_HERE"
+
+		// swiftlint:disable unused_optional_binding
+		guard let document = try? SwiftSoup.parse(self),
+			let _ = try? document.select("p").before(paragraphIdentifier),
+			let text = try? document.text() else {
+			return NSMutableAttributedString()
+		}
+		// swiftlint:enable unused_optional_binding
+
+		return NSMutableAttributedString(string: text.replacingOccurrences(of: paragraphIdentifier + " ", with: "\n\n"))
+	}
 }

--- a/App/Main.storyboard
+++ b/App/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="506-JC-FDt">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="506-JC-FDt">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -32,7 +33,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No post selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ein-MP-Pvn">
-                                <rect key="frame" x="97" y="318.5" width="181.5" height="30"/>
+                                <rect key="frame" x="86" y="317" width="203.5" height="33.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" name="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -64,7 +65,7 @@
                         <color key="separatorColor" name="separatorColor"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PostCell" rowHeight="77" id="bpe-eU-o38" customClass="PostCell" customModule="Hackers" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="375" height="77"/>
+                                <rect key="frame" x="0.0" y="50" width="375" height="77"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bpe-eU-o38" id="BKa-yl-PzM">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="77"/>
@@ -89,19 +90,19 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fFz-HF-Y5S" customClass="PostTitleView" customModule="Hackers" customModuleProvider="target">
-                                                    <rect key="frame" x="72" y="9.5" width="273" height="36.5"/>
+                                                    <rect key="frame" x="72" y="7" width="273" height="41.5"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="siM-Zi-8Sk">
-                                                            <rect key="frame" x="0.0" y="0.0" width="273" height="36.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="273" height="41.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title Text" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WXV-Sp-0Vs">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="273" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="273" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                     <color key="textColor" name="titleTextColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="1 point" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRf-um-i92">
-                                                                    <rect key="frame" x="0.0" y="22" width="273" height="14.5"/>
+                                                                    <rect key="frame" x="0.0" y="25.5" width="273" height="16"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                     <color key="textColor" name="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -150,7 +151,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="OpenCommentCell" rowHeight="144" id="cqK-Qe-Eib" userLabel="Open Comment Cell" customClass="CommentTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="121.5" width="375" height="144"/>
+                                <rect key="frame" x="0.0" y="127" width="375" height="144"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cqK-Qe-Eib" id="cbj-iP-y7N">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="144"/>
@@ -234,7 +235,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ClosedCommentCell" rowHeight="42" id="SRx-1V-zp4" userLabel="Closed Comment Cell" customClass="CommentTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="265.5" width="375" height="42"/>
+                                <rect key="frame" x="0.0" y="271" width="375" height="42"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SRx-1V-zp4" id="MAZ-eW-f1R">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="42"/>
@@ -304,10 +305,74 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <segue destination="ozE-fK-sDZ" kind="presentation" identifier="ShowTextSelectionSegue" id="IIR-lL-SMT"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZK9-xq-FV6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4074" y="546"/>
+        </scene>
+        <!--Select Text-->
+        <scene sceneID="x8d-A2-KEL">
+            <objects>
+                <navigationController title="Select Text" id="ozE-fK-sDZ" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="vl6-C0-1Os">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="iMC-4m-ZPQ" kind="relationship" relationship="rootViewController" id="mSf-15-Jv5"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="UQC-fj-N50" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4073" y="1397"/>
+        </scene>
+        <!--Text Selection View Controller-->
+        <scene sceneID="Kxi-mw-q0c">
+            <objects>
+                <viewController id="iMC-4m-ZPQ" customClass="TextSelectionViewController" customModule="Hackers" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="qem-z7-MD4">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" contentInsetAdjustmentBehavior="always" editable="NO" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="ex9-nV-QsL">
+                                <rect key="frame" x="0.0" y="56" width="375" height="591"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" name="appTintColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6GH-Me-8qr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ex9-nV-QsL" firstAttribute="top" secondItem="6GH-Me-8qr" secondAttribute="top" id="28R-Oy-9el"/>
+                            <constraint firstItem="6GH-Me-8qr" firstAttribute="trailing" secondItem="ex9-nV-QsL" secondAttribute="trailing" id="8M0-uA-971"/>
+                            <constraint firstItem="6GH-Me-8qr" firstAttribute="bottom" secondItem="ex9-nV-QsL" secondAttribute="bottom" id="8cC-rF-95T"/>
+                            <constraint firstItem="ex9-nV-QsL" firstAttribute="leading" secondItem="6GH-Me-8qr" secondAttribute="leading" id="sBQ-UH-2BG"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="as6-0R-MHp">
+                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="done" id="vLV-wD-oKW">
+                            <color key="tintColor" name="titleTextColor"/>
+                            <connections>
+                                <action selector="didPressDone:" destination="iMC-4m-ZPQ" id="mLe-QH-ihC"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="title" value="Select Text"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <outlet property="commentTextView" destination="ex9-nV-QsL" id="7Xb-R8-d1q"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="T4Z-We-8aE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4916" y="1397"/>
         </scene>
         <!--Settings Navigation Controller-->
         <scene sceneID="CQx-j9-MSt">
@@ -333,11 +398,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="HBZ-Wx-9of">
-                            <rect key="frame" x="0.0" y="647.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="665.5" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version 3.0.0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vai-hd-k76">
-                                    <rect key="frame" x="151" y="15" width="73.5" height="14.5"/>
+                                    <rect key="frame" x="148" y="14" width="79" height="16"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -401,11 +466,11 @@
                                         <rect key="frame" x="16" y="131" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eLs-tl-nhE" id="dHF-kW-kGX">
-                                            <rect key="frame" x="0.0" y="0.0" width="318.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="316.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Hackers on GitHub" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qQX-ZY-Ize">
-                                                    <rect key="frame" x="16" y="0.0" width="294.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="292.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -419,11 +484,11 @@
                                         <rect key="frame" x="16" y="174.5" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d8U-Ru-hVy" id="9oy-Wa-MHK">
-                                            <rect key="frame" x="0.0" y="0.0" width="318.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="316.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Send Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Mol-08-1sm">
-                                                    <rect key="frame" x="16" y="0.0" width="294.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="292.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -437,11 +502,11 @@
                                         <rect key="frame" x="16" y="218" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="As0-J3-za5" id="GYg-SA-IFp">
-                                            <rect key="frame" x="0.0" y="0.0" width="318.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="316.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="What's New" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Mop-dp-piY">
-                                                    <rect key="frame" x="16" y="0.0" width="294.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="292.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -456,10 +521,10 @@
                             <tableViewSection headerTitle="Login" id="cxD-wx-jlJ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="EN8-wt-Iug" detailTextLabel="PDK-aN-wRW" style="IBUITableViewCellStyleValue1" id="b2z-TO-21M" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="311.5" width="343" height="43.5"/>
+                                        <rect key="frame" x="16" y="317.5" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b2z-TO-21M" id="Nqt-rx-GbL">
-                                            <rect key="frame" x="0.0" y="0.0" width="318.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="316.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="EN8-wt-Iug">
@@ -470,7 +535,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Not logged in" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PDK-aN-wRW">
-                                                    <rect key="frame" x="208" y="12" width="102.5" height="20.5"/>
+                                                    <rect key="frame" x="206" y="12" width="102.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -485,14 +550,14 @@
                             <tableViewSection headerTitle="Interface" id="gib-U9-aJ3" userLabel="Feed">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="XYf-0N-FG9" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="405" width="343" height="43.5"/>
+                                        <rect key="frame" x="16" y="417" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XYf-0N-FG9" id="QjQ-cP-q8a">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Thumbnails" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="65F-Rn-FAZ">
-                                                    <rect key="frame" x="16" y="13.5" width="114" height="17"/>
+                                                    <rect key="frame" x="16" y="11.5" width="135" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -517,14 +582,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="ila-G7-nJ9" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="448.5" width="343" height="43.5"/>
+                                        <rect key="frame" x="16" y="460.5" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ila-G7-nJ9" id="pfP-AY-HJQ">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swipe Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MXF-rP-Tah">
-                                                    <rect key="frame" x="16" y="13.5" width="91.5" height="17"/>
+                                                    <rect key="frame" x="16" y="11.5" width="107.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -550,14 +615,14 @@
                             <tableViewSection headerTitle="Reading" id="1AH-ih-fLT">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="by2-0S-CnW" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="542" width="343" height="43.5"/>
+                                        <rect key="frame" x="16" y="560" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="by2-0S-CnW" id="l0C-ZL-f1a">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open in Default Browser" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dcq-dD-Aiv">
-                                                    <rect key="frame" x="16" y="13.5" width="157" height="17"/>
+                                                    <rect key="frame" x="16" y="11.5" width="185" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -579,14 +644,14 @@
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="SLb-pc-dXs" customClass="SettingsTableViewCell" customModule="Hackers" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="585.5" width="343" height="44"/>
+                                        <rect key="frame" x="16" y="603.5" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SLb-pc-dXs" id="6r6-dg-b6u">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Safari in Reader Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wlj-6e-BYP">
-                                                    <rect key="frame" x="16" y="13.5" width="181" height="17"/>
+                                                    <rect key="frame" x="16" y="12" width="213" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -647,7 +712,7 @@
                     <navigationItem key="navigationItem" id="nrG-IN-2HV"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Zkc-Rr-CEM">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Cqb-Ra-RJu">
@@ -666,7 +731,7 @@
             <objects>
                 <navigationController id="1Xz-Ly-pCg" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="214-FR-gRR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -724,8 +789,11 @@
     <resources>
         <image name="LaunchIcon" width="128" height="128"/>
         <image name="PointsIcon" width="14" height="14"/>
-        <image name="gear" catalog="system" width="128" height="119"/>
-        <image name="safari" catalog="system" width="128" height="121"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="safari" catalog="system" width="128" height="123"/>
+        <namedColor name="appTintColor">
+            <color red="0.396078431372549" green="0.074509803921568626" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="groupedTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
@@ -741,6 +809,9 @@
         <namedColor name="titleTextColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/App/Main.storyboard
+++ b/App/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="506-JC-FDt">
-    <device id="retina4_7" orientation="portrait" appearance="dark"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
@@ -313,10 +313,10 @@
             </objects>
             <point key="canvasLocation" x="4074" y="546"/>
         </scene>
-        <!--Select Text-->
+        <!--Select Text Navigation Controller-->
         <scene sceneID="x8d-A2-KEL">
             <objects>
-                <navigationController title="Select Text" id="ozE-fK-sDZ" sceneMemberID="viewController">
+                <navigationController title="Select Text" id="ozE-fK-sDZ" userLabel="Select Text Navigation Controller" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="vl6-C0-1Os">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Hackers.xcodeproj/project.pbxproj
+++ b/Hackers.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		24FF021D226C9BEA002EF8DD /* SwinjectStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FF021C226C9BEA002EF8DD /* SwinjectStoryboardExtensions.swift */; };
 		24FFFF5A23362C7800D009EF /* HackersKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FFFF5923362C7800D009EF /* HackersKitExtensions.swift */; };
 		698FE7B523EE5FE300F5828C /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 698FE7B423EE5FE300F5828C /* Colors.xcassets */; };
+		8B782E032A5AB01C00FD6B39 /* TextSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B782E022A5AB01C00FD6B39 /* TextSelectionViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -219,6 +220,7 @@
 		24FF021C226C9BEA002EF8DD /* SwinjectStoryboardExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardExtensions.swift; sourceTree = "<group>"; };
 		24FFFF5923362C7800D009EF /* HackersKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackersKitExtensions.swift; sourceTree = "<group>"; };
 		698FE7B423EE5FE300F5828C /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		8B782E022A5AB01C00FD6B39 /* TextSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSelectionViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -444,6 +446,7 @@
 				2454B9031F655426005A98C7 /* EmptyViewController.swift */,
 				24D811A41FF90A58000951C3 /* TouchableTextView.swift */,
 				24191F8C1944C991003C0D98 /* CommentsController.swift */,
+				8B782E022A5AB01C00FD6B39 /* TextSelectionViewController.swift */,
 			);
 			path = Comments;
 			sourceTree = "<group>";
@@ -878,6 +881,7 @@
 				249B8F8322A2A48B002A9EC5 /* NotificationToken.swift in Sources */,
 				2481BD61247C11AE0088CA2B /* HackersKit+CommentVoting.swift in Sources */,
 				24D330CA248BAC4C00A2AA10 /* HackersKit+Authentication.swift in Sources */,
+				8B782E032A5AB01C00FD6B39 /* TextSelectionViewController.swift in Sources */,
 				24C20D391A7E42D5005B759B /* MainSplitViewController.swift in Sources */,
 				2464D21F209E27FE00C7F8FC /* UserDefaultsExtensions.swift in Sources */,
 				24CE5FF819435A90009D2677 /* PostCell.swift in Sources */,


### PR DESCRIPTION
Added the ability to copy text of a comment or select part of a comment in the comments context menu.

Before             |  After
:-------------------------:|:-------------------------:
![IMG_2253](https://github.com/weiran/Hackers/assets/38043915/393b5bc1-38a5-4cde-aadb-4d4a86f31301) | ![IMG_2252](https://github.com/weiran/Hackers/assets/38043915/257826cd-f540-4b25-ba6c-b7b4848a6682)
![IMG_2248](https://github.com/weiran/Hackers/assets/38043915/cafe1f78-13d9-402b-9425-14359580cf3c) | ![IMG_2249](https://github.com/weiran/Hackers/assets/38043915/f0578f0f-8c75-4dc7-a23c-484a2b0e94c3)

## Text Selection

<img src=https://github.com/weiran/Hackers/assets/38043915/86150e85-c13e-4e39-b1a2-c34631dcdedc width="425"/>