### PR TITLE
Comment count refresh [bug fix]

### DIFF
--- a/App/Comments/CommentsViewController.swift
+++ b/App/Comments/CommentsViewController.swift
@@ -65,6 +65,7 @@ class CommentsViewController: UITableViewController {
             return self.loadComments(for: post)
         }.done { comments in
             self.comments = comments
+			self.post?.commentsCount = comments.count
             self.tableView.reloadData()
         }.catch { error in
             UINotifications.showError()

--- a/App/Comments/CommentsViewController.swift
+++ b/App/Comments/CommentsViewController.swift
@@ -65,7 +65,7 @@ class CommentsViewController: UITableViewController {
             return self.loadComments(for: post)
         }.done { comments in
             self.comments = comments
-			self.post?.commentsCount = comments.count
+            self.post?.commentsCount = comments.count
             self.tableView.reloadData()
         }.catch { error in
             UINotifications.showError()

--- a/Shared Frameworks/HackersKit/Models/Models.swift
+++ b/Shared Frameworks/HackersKit/Models/Models.swift
@@ -13,7 +13,7 @@ class Post: Hashable {
     let url: URL
     let title: String
     let age: String
-    let commentsCount: Int
+    var commentsCount: Int
     let by: String
     var score: Int
     let postType: PostType


### PR DESCRIPTION
When refreshing comments, the comment count would remain the same due to using the same post the viewController loaded with.

This change updates the comment count when refreshing the comments.