### PR TITLE
Pin github actions to commit-hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
     - name: Install SwiftLint
@@ -26,8 +26,8 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: AckeeCZ/load-xcode-version@v1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: AckeeCZ/load-xcode-version@171fc8614ffa6b7d50ea7bdb5936c7d8efd8361e # v1
     - name: Run UI Tests
       run: fastlane test
 
@@ -35,9 +35,9 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
-    - uses: AckeeCZ/load-xcode-version@v1
+    - uses: AckeeCZ/load-xcode-version@171fc8614ffa6b7d50ea7bdb5936c7d8efd8361e # v1
     - name: Build
       run: fastlane build


### PR DESCRIPTION
Follow the recent compromise of [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), this PR pins GitHub actions to specific commit hashes to ensure a known version of each action is used, mitigating the risk of a supply chain attack through malicious updates.

[See related blog post by rafaelgss about pinning to the commit-hash](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash).