### PR TITLE
Add Active category to Hacker News feed

### DIFF
--- a/App/Extensions/HackersKitExtensions.swift
+++ b/App/Extensions/HackersKitExtensions.swift
@@ -23,6 +23,7 @@ extension PostType {
         case .jobs: return "Jobs"
         case .newest: return "New"
         case .best: return "Best"
+        case .active: return "Active"
         }
     }
 
@@ -34,6 +35,7 @@ extension PostType {
         case .jobs: return "briefcase"
         case .newest: return "clock"
         case .best: return "rosette"
+        case .active: return "bolt"
         }
     }
 }

--- a/Shared Frameworks/HackersKit/HackersKit+PostsList.swift
+++ b/Shared Frameworks/HackersKit/HackersKit+PostsList.swift
@@ -25,6 +25,8 @@ extension HackersKit {
         var url: URL
         if type == .newest || type == .jobs {
             url = URL(string: "https://news.ycombinator.com/\(type.rawValue)?next=\(nextId)")!
+        } else if type == .active {
+            url = URL(string: "https://news.ycombinator.com/active?p=\(page)")!
         } else {
             url = URL(string: "https://news.ycombinator.com/\(type.rawValue)?p=\(page)")!
         }

--- a/Shared Frameworks/HackersKit/Models/Models.swift
+++ b/Shared Frameworks/HackersKit/Models/Models.swift
@@ -60,6 +60,7 @@ enum PostType: String, CaseIterable {
     case jobs
     case newest
     case best
+    case active
 }
 
 class Comment: Hashable {


### PR DESCRIPTION
 Description:
  ## Summary
  - Add new "Active" category to the feed selector that shows posts with
  recent activity/discussion
  - Fetches data from https://news.ycombinator.com/active
  - Includes proper pagination support using page-based navigation

  ## Changes
  - Added `active` case to `PostType` enum in `Models.swift`
  - Added "Active" title and bolt icon in `HackersKitExtensions.swift`
  - Implemented URL handling and pagination for Active feed in
  `HackersKit+PostsList.swift`

  ## Test plan
  - [x] Build compiles successfully for iOS Simulator
  - [x] Active category appears in the feed selector dropdown
  - [x] Active feed loads posts from the correct URL
  - [x] Pagination works when scrolling to bottom of Active feed
  - [x] Manual testing on device/simulator to verify UI and functionality

  🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for an "Active" post type, including a new icon and title.
  * Added the ability to fetch and display "Active" posts with dedicated handling in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->