### PR TITLE
Fix pagination for Ask feed and other feeds with fewer posts

### DIFF
--- a/App/Feed/FeedCollectionViewController.swift
+++ b/App/Feed/FeedCollectionViewController.swift
@@ -187,7 +187,8 @@ extension FeedCollectionViewController: UICollectionViewDelegate {
         willDisplay cell: UICollectionViewCell,
         forItemAt indexPath: IndexPath
     ) {
-        if indexPath.row == viewModel.posts.count - 5 && !viewModel.isFetching {
+        let remainingItems = viewModel.posts.count - indexPath.row - 1
+        if remainingItems <= 5 && remainingItems >= 0 && !viewModel.isFetching {
             fetchFeedNextPage()
         }
     }


### PR DESCRIPTION
- Change pagination trigger from exact index match to remaining items check
- Fixes issue where Ask pages with fewer than 5 posts couldn't trigger pagination
- Now triggers when there are 5 or fewer items remaining to display
- Improves pagination reliability across all feed types

Problem: Ask feed pagination wasn't working because pages 2+ often have very few posts, and the trigger `indexPath.row == viewModel.posts.count - 5` would never match when there were fewer than 5 total posts.

Solution: Calculate remaining items and trigger when ≤ 5 items remain, ensuring pagination works regardless of total post count.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for loading additional posts in the feed, ensuring smoother and more reliable fetching as users scroll near the end of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->