### PR TITLE
Fix crash when tapping Hacker News comment permalinks

### DIFF
--- a/App/Comments/CommentTableViewCell.swift
+++ b/App/Comments/CommentTableViewCell.swift
@@ -101,11 +101,9 @@ extension CommentTableViewCell: UITextViewDelegate {
                     if
                         let host = URL.host,
                         host.contains("news.ycombinator.com"),
-                        let range = URL.absoluteString.range(of: "id="),
-                        let id = Int(
-                            URL.absoluteString[range.upperBound...]
-                                .trimmingCharacters(in: .whitespaces)
-                            ) {
+                        let components = URLComponents(url: URL, resolvingAgainstBaseURL: true),
+                        let idString = components.queryItems?.first(where: { $0.name == "id" })?.value,
+                        let id = Int(idString) {
                         commentDelegate.internalLinkTapped(postId: id, url: URL, sender: textView)
                     } else {
                         commentDelegate.linkTapped(URL, sender: textView)

--- a/Shared Frameworks/HackersKit/HtmlParser.swift
+++ b/Shared Frameworks/HackersKit/HtmlParser.swift
@@ -42,7 +42,10 @@ enum HtmlParser {
             throw Exception.Error(type: .SelectorParseException, Message: "Couldn't parse post ID")
         }
         let urlString = try postElement.select(".titleline").select("a").attr("href")
-        let title = try postElement.select(".titleline").select("a").first()!.text()
+        guard let titleElement = try postElement.select(".titleline").select("a").first() else {
+            throw Exception.Error(type: .SelectorParseException, Message: "Couldn't find title element")
+        }
+        let title = try titleElement.text()
         guard let url = URL(string: urlString) else {
             throw Exception.Error(type: .SelectorParseException, Message: "Couldn't parse post URL")
         }


### PR DESCRIPTION
- Replace fragile string manipulation with robust URLComponents parsing in CommentTableViewCell
- Add defensive programming to HtmlParser to handle comment permalink HTML structure
- Prevents crash on line 45 of HtmlParser when parsing comment pages
- Fixes issue #294: app now gracefully handles comment permalinks

🤖 Generated with [Claude Code](https://claude.ai/code)

Resolves #294 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of URL interactions to safely extract post IDs from links, reducing the risk of errors when opening internal links.
  * Enhanced error handling when parsing titles from HTML, preventing potential crashes if expected elements are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->