### PR TITLE
Fix empty comment appearing at top of non-Ask HN posts

### DIFF
--- a/Shared Frameworks/HackersKit/HackersKit+Post.swift
+++ b/Shared Frameworks/HackersKit/HackersKit+Post.swift
@@ -30,29 +30,13 @@ extension HackersKit {
         }
 
         // get the post text for AskHN
-        let postTableElement = try HtmlParser.postsTableElement(from: html)
-        if let post = try HtmlParser.posts(from: postTableElement, type: .news).first,
-            let postComment = self.postComment(from: post) {
+        if let postComment = try? HtmlParser.postComment(from: html) {
             comments.insert(postComment, at: 0)
         }
 
         return comments
     }
 
-    private func postComment(from post: Post) -> Comment? {
-        if let text = post.text {
-            return Comment(
-                id: post.id,
-                age: post.age,
-                text: text,
-                by: post.by,
-                level: 0,
-                upvoted: post.upvoted
-            )
-        }
-
-        return nil
-    }
 
     /// Optionally recursively fetch post comments over pages
     private func fetchPostHtml(


### PR DESCRIPTION
## Summary
• Fixed phantom empty comments appearing at the top of every post's comment section
• Only Ask HN posts with actual author text should show post comments
• Refactored comment parsing logic for better maintainability

## Root Cause
The comment parsing logic was creating empty comments from post metadata for all post types, not just Ask HN posts. The `.comtr` selector was also picking up elements without proper comment structure.

## Changes
• Added validation to skip comments with empty text in `HtmlParser.comment()`
• Moved post comment logic to new `HtmlParser.postComment()` method
• Only create post comments when `.toptext` div contains actual content
• Simplified and cleaned up comment parsing code in `HackersKit+Post.swift`

## Test Plan
- [x] Verify regular posts no longer show empty comments at the top
- [x] Confirm Ask HN posts with author text still show post comments correctly
- [x] Check that deleted/empty comments are properly filtered out
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or deleted comments, ensuring they are skipped and not displayed.
* **Refactor**
  * Simplified the process of extracting and displaying the post's own comment, resulting in more reliable comment ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->