### PR TITLE
Show loading state when switching category

### DIFF
--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -125,7 +125,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
         Group {
             if viewModel.hasActiveSearch {
                 searchContentView
-            } else if viewModel.isLoading && viewModel.posts.isEmpty && viewModel.postType != .bookmarks {
+            } else if shouldShowLoadingState {
                 AppLoadingStateView(message: "Loading...")
             } else if shouldShowBookmarksEmptyState {
                 AppEmptyStateView(
@@ -141,6 +141,15 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
             }
         }
         .animation(.default, value: viewModel.hasActiveSearch)
+    }
+
+    private var shouldShowLoadingState: Bool {
+        // Show loading when changing categories (selectedPostType != viewModel.postType)
+        // or when initially loading (isLoading && posts.isEmpty)
+        // but not for bookmarks which load instantly
+        let isChangingCategory = selectedPostType != viewModel.postType && selectedPostType != .bookmarks
+        let isInitialLoad = viewModel.isLoading && viewModel.posts.isEmpty && viewModel.postType != .bookmarks
+        return isChangingCategory || isInitialLoad
     }
 
     @ViewBuilder

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -121,7 +121,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
         Group {
             if viewModel.hasActiveSearch {
                 searchContentView
-            } else if viewModel.isChangingCategory || (viewModel.isLoading && viewModel.posts.isEmpty) {
+            } else if viewModel.isLoading && viewModel.posts.isEmpty && viewModel.postType != .bookmarks {
                 AppLoadingStateView(message: "Loading...")
             } else if shouldShowBookmarksEmptyState {
                 AppEmptyStateView(

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -92,6 +92,10 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     searchText = newValue
                 }
             }
+            .onChange(of: selectedPostType) { _ in
+                // Clear selection when category changes to prevent stale sidebar selection
+                selectedPostId = nil
+            }
         .task { @Sendable in
             // Set the navigation store for the voting view model
             votingViewModel.navigationStore = navigationStore

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -125,7 +125,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
         Group {
             if viewModel.hasActiveSearch {
                 searchContentView
-            } else if shouldShowLoadingState {
+            } else if viewModel.isLoading && viewModel.posts.isEmpty && viewModel.postType != .bookmarks {
                 AppLoadingStateView(message: "Loading...")
             } else if shouldShowBookmarksEmptyState {
                 AppEmptyStateView(
@@ -141,15 +141,6 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
             }
         }
         .animation(.default, value: viewModel.hasActiveSearch)
-    }
-
-    private var shouldShowLoadingState: Bool {
-        // Show loading when changing categories (selectedPostType != viewModel.postType)
-        // or when initially loading (isLoading && posts.isEmpty)
-        // but not for bookmarks which load instantly
-        let isChangingCategory = selectedPostType != viewModel.postType && selectedPostType != .bookmarks
-        let isInitialLoad = viewModel.isLoading && viewModel.posts.isEmpty && viewModel.postType != .bookmarks
-        return isChangingCategory || isInitialLoad
     }
 
     @ViewBuilder

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -164,24 +164,15 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
     }
 
     private func feedListView(posts: [Domain.Post], enablePagination: Bool) -> some View {
-        ScrollViewReader { proxy in
-            List(selection: selectionBinding) {
-                ForEach(posts, id: \.id) { post in
-                    postRow(for: post, enablePagination: enablePagination)
-                }
-            }
-            .if(isSidebar) { view in view.listStyle(.sidebar) }
-            .if(!isSidebar) { view in view.listStyle(.plain) }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onChange(of: selectedPostType) { _ in
-                // Scroll to top when category changes
-                if let firstPost = posts.first {
-                    withAnimation {
-                        proxy.scrollTo(firstPost.id, anchor: .top)
-                    }
-                }
+        List(selection: selectionBinding) {
+            ForEach(posts, id: \.id) { post in
+                postRow(for: post, enablePagination: enablePagination)
             }
         }
+        .if(isSidebar) { view in view.listStyle(.sidebar) }
+        .if(!isSidebar) { view in view.listStyle(.plain) }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .id(selectedPostType)
     }
 
     @ViewBuilder

--- a/Features/Feed/Sources/Feed/FeedViewModel.swift
+++ b/Features/Feed/Sources/Feed/FeedViewModel.swift
@@ -15,7 +15,6 @@ import SwiftUI
 public final class FeedViewModel: @unchecked Sendable {
     public var isLoadingMore = false
     public var postType: Domain.PostType = .news
-    public var isChangingCategory = false
 
     private var postIds: Set<Int> = Set()
     private var pageIndex = 1
@@ -214,17 +213,7 @@ public final class FeedViewModel: @unchecked Sendable {
 
         postType = newType
         persistLastFeedCategoryIfNeeded()
-
-        // Show loading state for non-bookmark categories
-        if newType != .bookmarks {
-            isChangingCategory = true
-        }
-
         await refreshFeed()
-
-        if newType != .bookmarks {
-            isChangingCategory = false
-        }
     }
 
     @MainActor

--- a/Features/Feed/Sources/Feed/FeedViewModel.swift
+++ b/Features/Feed/Sources/Feed/FeedViewModel.swift
@@ -213,7 +213,8 @@ public final class FeedViewModel: @unchecked Sendable {
 
         postType = newType
         persistLastFeedCategoryIfNeeded()
-        await refreshFeed()
+        reset()  // Clear posts immediately to prevent flash of old data
+        await feedLoader.refresh()
     }
 
     @MainActor

--- a/Features/Feed/Sources/Feed/FeedViewModel.swift
+++ b/Features/Feed/Sources/Feed/FeedViewModel.swift
@@ -15,6 +15,7 @@ import SwiftUI
 public final class FeedViewModel: @unchecked Sendable {
     public var isLoadingMore = false
     public var postType: Domain.PostType = .news
+    public var isChangingCategory = false
 
     private var postIds: Set<Int> = Set()
     private var pageIndex = 1
@@ -213,7 +214,17 @@ public final class FeedViewModel: @unchecked Sendable {
 
         postType = newType
         persistLastFeedCategoryIfNeeded()
+
+        // Show loading state for non-bookmark categories
+        if newType != .bookmarks {
+            isChangingCategory = true
+        }
+
         await refreshFeed()
+
+        if newType != .bookmarks {
+            isChangingCategory = false
+        }
     }
 
     @MainActor

--- a/Features/Feed/Sources/Feed/FeedViewModel.swift
+++ b/Features/Feed/Sources/Feed/FeedViewModel.swift
@@ -213,12 +213,15 @@ public final class FeedViewModel: @unchecked Sendable {
 
         postType = newType
         persistLastFeedCategoryIfNeeded()
-        reset()  // Clear posts immediately to prevent flash of old data
+        reset(clearPosts: true)  // Clear posts immediately to prevent flash of old data
         await feedLoader.refresh()
     }
 
     @MainActor
-    private func reset() {
+    private func reset(clearPosts: Bool = false) {
+        if clearPosts {
+            feedLoader.data = []
+        }
         postIds = Set()
         pageIndex = 1
         lastPostId = 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sidebar selection now resets when switching post types to avoid stale selections.
  * Loading indicator refined: shown only during active loading when no posts exist and not in bookmarks view.
  * Feed list identity updated so the list refreshes correctly when changing between post types, ensuring the view clears and reloads as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->