### PR TITLE
Unvoting

### DIFF
--- a/Data/Sources/Data/PostRepository+Voting.swift
+++ b/Data/Sources/Data/PostRepository+Voting.swift
@@ -37,7 +37,23 @@ extension PostRepository {
         if containsLoginForm { throw HackersKitError.unauthenticated }
     }
 
-    // Unvote functionality removed
+    public func unvote(post: Post) async throws {
+        guard let voteLinks = post.voteLinks else { throw HackersKitError.unauthenticated }
+        guard let unvoteURL = voteLinks.unvote else {
+            throw HackersKitError.scraperError
+        }
+
+        let fullURLString = unvoteURL.absoluteString.hasPrefix("http")
+            ? unvoteURL.absoluteString
+            : urlBase + "/" + unvoteURL.absoluteString
+        guard let realURL = URL(string: fullURLString) else { throw HackersKitError.scraperError }
+
+        let response = try await networkManager.get(url: realURL)
+        let containsLoginForm =
+            response.contains("<form action=\"/login") ||
+            response.contains("You have to be logged in")
+        if containsLoginForm { throw HackersKitError.unauthenticated }
+    }
 
     public func upvote(comment: Domain.Comment, for _: Post) async throws {
         guard let voteLinks = comment.voteLinks else { throw HackersKitError.unauthenticated }
@@ -58,7 +74,23 @@ extension PostRepository {
         await MainActor.run { comment.upvoted = true }
     }
 
-    // Unvote functionality removed
+    public func unvote(comment: Domain.Comment, for _: Post) async throws {
+        guard let voteLinks = comment.voteLinks else { throw HackersKitError.unauthenticated }
+        guard let unvoteURL = voteLinks.unvote else {
+            throw HackersKitError.scraperError
+        }
+
+        let fullURLString = unvoteURL.absoluteString.hasPrefix("http")
+            ? unvoteURL.absoluteString
+            : urlBase + "/" + unvoteURL.absoluteString
+        guard let realURL = URL(string: fullURLString) else { throw HackersKitError.scraperError }
+
+        let response = try await networkManager.get(url: realURL)
+        let containsLoginForm = response.contains("<form action=\"/login")
+        if containsLoginForm { throw HackersKitError.unauthenticated }
+
+        await MainActor.run { comment.upvoted = false }
+    }
 
     // MARK: - Vote link extraction
 

--- a/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
@@ -356,14 +356,25 @@ public struct PostDisplayView: View {
             Capsule()
                 .fill(backgroundColor)
         )
-        Button(action: action ?? {}) {
-            content
+        return Button(action: action ?? {}) {
+            ZStack {
+                content
+                if isLoading {
+                    Capsule()
+                        .fill(backgroundColor.opacity(0.6))
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .tint(textColor)
+                }
+            }
         }
         .buttonStyle(.plain)
+        .disabled(!isEnabled || isLoading || action == nil)
+        .allowsHitTesting(isEnabled && !isLoading && action != nil)
+        .opacity(isEnabled && !isLoading ? 1.0 : 0.6)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(accessibilityHint ?? "")
-
     }
 }
 

--- a/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
@@ -27,6 +27,12 @@ public struct PostDisplayView: View {
     @State private var displayedUpvoted: Bool
     @State private var displayedBookmarked: Bool
     @State private var displayedVoteLinks: VoteLinks?
+    @State private var pendingVoteIntent: VoteIntent?
+
+    private enum VoteIntent {
+        case upvote
+        case unvote
+    }
 
     public init(
         post: Post,
@@ -127,6 +133,11 @@ public struct PostDisplayView: View {
                 displayedUpvoted = newValue
             }
         }
+        .onChange(of: votingState?.canUnvote) { _ in
+            if let voteLinks = post.voteLinks {
+                displayedVoteLinks = voteLinks
+            }
+        }
     }
 
     private var upvotePill: some View {
@@ -221,55 +232,88 @@ public struct PostDisplayView: View {
 
     private func makeUpvoteAction() -> (() -> Void)? {
         return {
-            guard !isSubmittingUpvote else { return }
-
-            let isCurrentlyUpvoted = displayedUpvoted
             let currentVoteLinks = displayedVoteLinks ?? post.voteLinks
             let canUnvote = currentVoteLinks?.unvote != nil
+            let intent: VoteIntent = (displayedUpvoted && canUnvote) ? .unvote : .upvote
+            Task { @MainActor in
+                handleVoteIntent(intent)
+            }
+        }
+    }
 
-            // If already upvoted and can unvote, perform unvote
-            if isCurrentlyUpvoted && canUnvote {
-                guard let onUnvoteTap else { return }
-                isSubmittingUpvote = true
-                let previousScore = displayedScore
-                let previousUpvoted = displayedUpvoted
-                let previousVoteLinks = currentVoteLinks
-                displayedUpvoted = false
-                displayedScore -= 1
-                displayedVoteLinks = VoteLinks(upvote: previousVoteLinks?.upvote, unvote: nil)
-                Task {
-                    let success = await onUnvoteTap()
-                    await MainActor.run {
-                        if !success {
-                            displayedScore = previousScore
-                            displayedUpvoted = previousUpvoted
-                            displayedVoteLinks = previousVoteLinks
-                        }
-                        isSubmittingUpvote = false
+    @MainActor
+    private func handleVoteIntent(_ intent: VoteIntent) {
+        if isSubmittingUpvote {
+            pendingVoteIntent = intent
+            return
+        }
+        executeVoteIntent(intent)
+    }
+
+    @MainActor
+    private func executeVoteIntent(_ intent: VoteIntent) {
+        pendingVoteIntent = nil
+
+        let currentVoteLinks = displayedVoteLinks ?? post.voteLinks
+        let previousScore = displayedScore
+        let previousUpvoted = displayedUpvoted
+        let previousVoteLinks = currentVoteLinks
+
+        switch intent {
+        case .unvote:
+            guard let onUnvoteTap else { return }
+            guard displayedUpvoted else { return }
+
+            isSubmittingUpvote = true
+            displayedUpvoted = false
+            displayedScore -= 1
+            displayedVoteLinks = VoteLinks(upvote: previousVoteLinks?.upvote, unvote: nil)
+
+            Task {
+                let success = await onUnvoteTap()
+                await MainActor.run {
+                    if !success {
+                        displayedScore = previousScore
+                        displayedUpvoted = previousUpvoted
+                        displayedVoteLinks = previousVoteLinks
                     }
-                }
-            } else {
-                // Perform upvote
-                guard let onUpvoteTap else { return }
-                isSubmittingUpvote = true
-                let previousScore = displayedScore
-                let previousUpvoted = displayedUpvoted
-                let previousVoteLinks = currentVoteLinks
-                displayedUpvoted = true
-                displayedScore += 1
-                displayedVoteLinks = derivedVoteLinks(afterUpvoteFrom: previousVoteLinks)
-                Task {
-                    let success = await onUpvoteTap()
-                    await MainActor.run {
-                        if !success {
-                            displayedScore = previousScore
-                            displayedUpvoted = previousUpvoted
-                            displayedVoteLinks = previousVoteLinks
-                        }
-                        isSubmittingUpvote = false
-                    }
+                    isSubmittingUpvote = false
+                    processPendingVoteIntentIfNeeded()
                 }
             }
+
+        case .upvote:
+            guard let onUpvoteTap else { return }
+            guard !displayedUpvoted else { return }
+            guard currentVoteLinks?.upvote != nil else { return }
+
+            isSubmittingUpvote = true
+            displayedUpvoted = true
+            displayedScore += 1
+            displayedVoteLinks = derivedVoteLinks(afterUpvoteFrom: previousVoteLinks)
+
+            Task {
+                let success = await onUpvoteTap()
+                await MainActor.run {
+                    if !success {
+                        displayedScore = previousScore
+                        displayedUpvoted = previousUpvoted
+                        displayedVoteLinks = previousVoteLinks
+                    } else {
+                        displayedVoteLinks = derivedVoteLinks(afterUpvoteFrom: displayedVoteLinks ?? previousVoteLinks)
+                    }
+                    isSubmittingUpvote = false
+                    processPendingVoteIntentIfNeeded()
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func processPendingVoteIntentIfNeeded() {
+        if let nextIntent = pendingVoteIntent {
+            pendingVoteIntent = nil
+            handleVoteIntent(nextIntent)
         }
     }
 

--- a/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
@@ -189,6 +189,7 @@ public struct PostDisplayView: View {
             accessibilityLabel: "\(post.commentsCount) comments",
             isHighlighted: false,
             isLoading: false,
+            isEnabled: true,
             numericValue: post.commentsCount,
             action: onCommentsTap
         )
@@ -370,16 +371,27 @@ public struct PostDisplayView: View {
             }
         }
 
-        return Button(action: action ?? {}) {
+        let shouldDisable = !isEnabled || isLoading
+        let shouldBeInteractive = isEnabled && !isLoading && action != nil
+
+        // If enabled but no action, render as static view to avoid disabled styling
+        if isEnabled && !isLoading && action == nil {
             content
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityHint(accessibilityHint ?? "")
+        } else {
+            Button(action: action ?? {}) {
+                content
+            }
+            .buttonStyle(.plain)
+            .disabled(!shouldBeInteractive)
+            .allowsHitTesting(shouldBeInteractive)
+            .opacity(shouldDisable ? 0.6 : 1.0)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint(accessibilityHint ?? "")
         }
-        .buttonStyle(.plain)
-        .disabled(!isEnabled || isLoading || action == nil)
-        .allowsHitTesting(isEnabled && !isLoading && action != nil)
-        .opacity(isEnabled && !isLoading ? 1.0 : 0.6)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint(accessibilityHint ?? "")
     }
 }
 

--- a/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/PostDisplayView.swift
@@ -356,17 +356,22 @@ public struct PostDisplayView: View {
             Capsule()
                 .fill(backgroundColor)
         )
-        return Button(action: action ?? {}) {
-            ZStack {
-                content
-                if isLoading {
-                    Capsule()
-                        .fill(backgroundColor.opacity(0.6))
-                    ProgressView()
-                        .scaleEffect(0.6)
-                        .tint(textColor)
-                }
+        .overlay {
+            if isLoading {
+                Capsule()
+                    .fill(backgroundColor.opacity(0.6))
             }
+        }
+        .overlay {
+            if isLoading {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .tint(textColor)
+            }
+        }
+
+        return Button(action: action ?? {}) {
+            content
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled || isLoading || action == nil)

--- a/DesignSystem/Sources/DesignSystem/Components/VoteButton.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/VoteButton.swift
@@ -44,11 +44,11 @@ public struct VoteButton: View {
                 }
             }
         }
-        .disabled(!votingState.canVote || votingState.isVoting)
+        .disabled((!votingState.canVote && !votingState.canUnvote) || votingState.isVoting)
         .scaleEffect(votingState.isVoting ? 0.95 : 1.0)
         .animation(.easeInOut(duration: 0.1), value: votingState.isVoting)
-        .accessibilityLabel(votingState.isUpvoted ? "Upvoted" : "Upvote")
-        .accessibilityHint(votingState.isUpvoted ? "Already upvoted" : (votingState.canVote ? "Double-tap to upvote" : "Voting unavailable"))
+        .accessibilityLabel(votingState.isUpvoted && votingState.canUnvote ? "Unvote" : (votingState.isUpvoted ? "Upvoted" : "Upvote"))
+        .accessibilityHint(votingState.isUpvoted && votingState.canUnvote ? "Double-tap to unvote" : (votingState.isUpvoted ? "Already upvoted" : (votingState.canVote ? "Double-tap to upvote" : "Voting unavailable")))
         .accessibilityValue({ () -> String in
             if let score = votingState.score { return "\(score) points" }
             return ""

--- a/DesignSystem/Sources/DesignSystem/Components/VotingContextMenuItems.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/VotingContextMenuItems.swift
@@ -15,13 +15,22 @@ public enum VotingContextMenuItems {
     public static func postVotingMenuItems(
         for post: Post,
         onVote: @escaping @Sendable () -> Void,
+        onUnvote: @escaping @Sendable () -> Void = {},
     ) -> some View {
-        // Only show upvote if available and not already upvoted
+        // Show upvote if available and not already upvoted
         if post.voteLinks?.upvote != nil, !post.upvoted {
             Button {
                 onVote()
             } label: {
                 Label("Upvote", systemImage: "arrow.up")
+            }
+        }
+        // Show unvote if available and already upvoted
+        if post.voteLinks?.unvote != nil, post.upvoted {
+            Button {
+                onUnvote()
+            } label: {
+                Label("Unvote", systemImage: "arrow.uturn.down")
             }
         }
     }
@@ -32,13 +41,22 @@ public enum VotingContextMenuItems {
     public static func commentVotingMenuItems(
         for comment: Comment,
         onVote: @escaping @Sendable () -> Void,
+        onUnvote: @escaping @Sendable () -> Void = {},
     ) -> some View {
-        // Only show upvote if available and not already upvoted
+        // Show upvote if available and not already upvoted
         if comment.voteLinks?.upvote != nil, !comment.upvoted {
             Button {
                 onVote()
             } label: {
                 Label("Upvote", systemImage: "arrow.up")
+            }
+        }
+        // Show unvote if available and already upvoted
+        if comment.voteLinks?.unvote != nil, comment.upvoted {
+            Button {
+                onUnvote()
+            } label: {
+                Label("Unvote", systemImage: "arrow.uturn.down")
             }
         }
     }
@@ -49,13 +67,22 @@ public enum VotingContextMenuItems {
     public static func votingMenuItems(
         for item: some Votable,
         onVote: @escaping @Sendable () -> Void,
+        onUnvote: @escaping @Sendable () -> Void = {},
     ) -> some View {
-        // Only show upvote if available and not already upvoted
+        // Show upvote if available and not already upvoted
         if item.voteLinks?.upvote != nil, !item.upvoted {
             Button {
                 onVote()
             } label: {
                 Label("Upvote", systemImage: "arrow.up")
+            }
+        }
+        // Show unvote if available and already upvoted
+        if item.voteLinks?.unvote != nil, item.upvoted {
+            Button {
+                onUnvote()
+            } label: {
+                Label("Unvote", systemImage: "arrow.uturn.down")
             }
         }
     }
@@ -90,10 +117,11 @@ public extension View {
     func votingContextMenu(
         for item: some Votable,
         onVote: @escaping @Sendable () -> Void,
+        onUnvote: @escaping @Sendable () -> Void = {},
         additionalItems: @escaping () -> some View = { EmptyView() },
     ) -> some View {
         contextMenu {
-            VotingContextMenuItems.votingMenuItems(for: item, onVote: onVote)
+            VotingContextMenuItems.votingMenuItems(for: item, onVote: onVote, onUnvote: onUnvote)
             additionalItems()
         }
     }

--- a/Domain/Sources/Domain/Models.swift
+++ b/Domain/Sources/Domain/Models.swift
@@ -14,6 +14,7 @@ public struct VotingState: Sendable {
     public let isUpvoted: Bool
     public let score: Int?
     public let canVote: Bool
+    public let canUnvote: Bool
     public let isVoting: Bool
     public let error: Error?
 
@@ -21,12 +22,14 @@ public struct VotingState: Sendable {
         isUpvoted: Bool,
         score: Int? = nil,
         canVote: Bool,
+        canUnvote: Bool = false,
         isVoting: Bool = false,
         error: Error? = nil,
     ) {
         self.isUpvoted = isUpvoted
         self.score = score
         self.canVote = canVote
+        self.canUnvote = canUnvote
         self.isVoting = isVoting
         self.error = error
     }

--- a/Domain/Sources/Domain/VoteUseCase.swift
+++ b/Domain/Sources/Domain/VoteUseCase.swift
@@ -10,4 +10,6 @@ import Foundation
 public protocol VoteUseCase: Sendable {
     func upvote(post: Post) async throws
     func upvote(comment: Comment, for post: Post) async throws
+    func unvote(post: Post) async throws
+    func unvote(comment: Comment, for post: Post) async throws
 }

--- a/Features/Comments/Sources/Comments/CommentsComponents.swift
+++ b/Features/Comments/Sources/Comments/CommentsComponents.swift
@@ -38,6 +38,7 @@ struct CommentsContentView: View {
                     PostHeader(
                         post: post,
                         votingViewModel: votingViewModel,
+                        isLoadingComments: viewModel.isLoading,
                         showThumbnails: viewModel.showThumbnails,
                         onLinkTap: { handleLinkTap() },
                         onPostUpdated: { updatedPost in
@@ -57,6 +58,7 @@ struct CommentsContentView: View {
                         view.swipeActions(edge: .leading, allowsFullSwipe: true) {
                             if post.upvoted && post.voteLinks?.unvote != nil {
                                 Button {
+                                    guard !viewModel.isLoading else { return }
                                     Task {
                                         var mutablePost = post
                                         await votingViewModel.unvote(post: &mutablePost)
@@ -74,8 +76,10 @@ struct CommentsContentView: View {
                                 }
                                 .tint(.orange)
                                 .accessibilityLabel("Unvote")
+                                .disabled(viewModel.isLoading)
                             } else {
                                 Button {
+                                    guard !viewModel.isLoading else { return }
                                     Task {
                                         var mutablePost = post
                                         await votingViewModel.upvote(post: &mutablePost)
@@ -90,6 +94,7 @@ struct CommentsContentView: View {
                                 }
                                 .tint(AppColors.upvotedColor)
                                 .accessibilityLabel("Upvote")
+                                .disabled(viewModel.isLoading)
                             }
                         }
                     }
@@ -218,6 +223,7 @@ struct CommentsForEach: View {
 struct PostHeader: View {
     let post: Post
     let votingViewModel: VotingViewModel
+    let isLoadingComments: Bool
     let showThumbnails: Bool
     let onLinkTap: () -> Void
     let onPostUpdated: @Sendable (Post) -> Void
@@ -256,6 +262,7 @@ struct PostHeader: View {
     }
 
     private func handleUpvote() async -> Bool {
+        guard !isLoadingComments else { return false }
         guard votingViewModel.canVote(item: post), !post.upvoted else { return false }
 
         var mutablePost = post
@@ -272,6 +279,7 @@ struct PostHeader: View {
     }
 
     private func handleUnvote() async -> Bool {
+        guard !isLoadingComments else { return true }
         guard votingViewModel.canUnvote(item: post), post.upvoted else { return true }
 
         var mutablePost = post

--- a/Features/Comments/Sources/Comments/CommentsComponents.swift
+++ b/Features/Comments/Sources/Comments/CommentsComponents.swift
@@ -63,12 +63,7 @@ struct CommentsContentView: View {
                                         var mutablePost = post
                                         await votingViewModel.unvote(post: &mutablePost)
                                         await MainActor.run {
-                                            if !mutablePost.upvoted {
-                                                if let existingLinks = mutablePost.voteLinks {
-                                                    mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
-                                                }
-                                                viewModel.post = mutablePost
-                                            }
+                                            viewModel.post = mutablePost
                                         }
                                     }
                                 } label: {
@@ -287,9 +282,6 @@ struct PostHeader: View {
         let wasUnvoted = !mutablePost.upvoted
 
         if wasUnvoted {
-            if let existingLinks = mutablePost.voteLinks {
-                mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
-            }
             await MainActor.run {
                 onPostUpdated(mutablePost)
             }

--- a/Features/Comments/Sources/Comments/CommentsComponents.swift
+++ b/Features/Comments/Sources/Comments/CommentsComponents.swift
@@ -62,6 +62,9 @@ struct CommentsContentView: View {
                                         await votingViewModel.unvote(post: &mutablePost)
                                         await MainActor.run {
                                             if !mutablePost.upvoted {
+                                                if let existingLinks = mutablePost.voteLinks {
+                                                    mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+                                                }
                                                 viewModel.post = mutablePost
                                             }
                                         }
@@ -276,6 +279,9 @@ struct PostHeader: View {
         let wasUnvoted = !mutablePost.upvoted
 
         if wasUnvoted {
+            if let existingLinks = mutablePost.voteLinks {
+                mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+            }
             await MainActor.run {
                 onPostUpdated(mutablePost)
             }

--- a/Features/Comments/Sources/Comments/CommentsView.swift
+++ b/Features/Comments/Sources/Comments/CommentsView.swift
@@ -114,6 +114,12 @@ public struct CommentsView<NavigationStore: NavigationStoreProtocol>: View {
         }
         .task {
             votingViewModel.navigationStore = navigationStore
+            // Set up callback to update navigation store when post changes
+            viewModel.onPostUpdated = { [weak navigationStore] updatedPost in
+                if let updatedPost {
+                    navigationStore?.selectedPost = updatedPost
+                }
+            }
             await viewModel.loadComments()
             if let targetID = pendingCommentID {
                 _ = await viewModel.revealComment(withId: targetID)

--- a/Features/Comments/Sources/Comments/CommentsViewModel.swift
+++ b/Features/Comments/Sources/Comments/CommentsViewModel.swift
@@ -14,12 +14,18 @@ import SwiftUI
 @Observable
 public final class CommentsViewModel: @unchecked Sendable {
     public let postID: Int
-    public var post: Post?
+    public var post: Post? {
+        didSet {
+            onPostUpdated?(post)
+        }
+    }
     public var visibleComments: [Comment] = []
     public var showThumbnails: Bool
 
     // Callback for when comments are loaded (used for HTML parsing in the view layer)
     public var onCommentsLoaded: (([Comment]) -> Void)?
+    // Callback for when post is updated
+    public var onPostUpdated: ((Post?) -> Void)?
 
     private let postUseCase: any PostUseCase
     private let commentUseCase: any CommentUseCase

--- a/Features/Comments/Tests/CommentsTests/CommentsViewModelTests.swift
+++ b/Features/Comments/Tests/CommentsTests/CommentsViewModelTests.swift
@@ -631,6 +631,18 @@ final class MockVoteUseCase: VoteUseCase, @unchecked Sendable {
             throw MockError.testError
         }
     }
+
+    func unvote(post _: Post) async throws {
+        if shouldThrowError {
+            throw MockError.testError
+        }
+    }
+
+    func unvote(comment _: Domain.Comment, for _: Post) async throws {
+        if shouldThrowError {
+            throw MockError.testError
+        }
+    }
 }
 
 final class StubSettingsUseCase: SettingsUseCase, @unchecked Sendable {

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -220,6 +220,9 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.unvote(post: &mutablePost)
                     await MainActor.run {
                         if !mutablePost.upvoted {
+                            if let existingLinks = mutablePost.voteLinks {
+                                mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+                            }
                             viewModel.replacePost(mutablePost)
                         }
                     }
@@ -270,6 +273,9 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.unvote(post: &mutablePost)
                     await MainActor.run {
                         if !mutablePost.upvoted {
+                            if let existingLinks = mutablePost.voteLinks {
+                                mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+                            }
                             viewModel.replacePost(mutablePost)
                         }
                     }
@@ -446,6 +452,9 @@ struct PostRowView: View {
         let wasUnvoted = !mutablePost.upvoted
 
         if wasUnvoted {
+            if let existingLinks = mutablePost.voteLinks {
+                mutablePost.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+            }
             await MainActor.run {
                 onPostUpdated?(mutablePost)
             }

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -97,6 +97,13 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
             votingViewModel.navigationStore = navigationStore
             await viewModel.loadFeed()
         }
+        .onChange(of: navigationStore.selectedPost) { oldPost, newPost in
+            // When selectedPost changes in navigation store (e.g., from comments view),
+            // update it in the feed
+            if let updatedPost = newPost {
+                viewModel.replacePost(updatedPost)
+            }
+        }
         .alert(
             "Vote Error",
             isPresented: Binding(

--- a/Features/Feed/Sources/Feed/FeedView.swift
+++ b/Features/Feed/Sources/Feed/FeedView.swift
@@ -182,8 +182,8 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
             showThumbnails: viewModel.showThumbnails,
             onLinkTap: { handleLinkTap(post: post) },
             onCommentsTap: isSidebar ? nil : { navigationStore.showPost(post) },
-            onUpvoteApplied: { postId in
-                viewModel.applyLocalUpvote(to: postId)
+            onPostUpdated: { updatedPost in
+                viewModel.replacePost(updatedPost)
             },
             onBookmarkToggle: {
                 await viewModel.toggleBookmark(for: post)
@@ -220,7 +220,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.unvote(post: &mutablePost)
                     await MainActor.run {
                         if !mutablePost.upvoted {
-                            viewModel.applyLocalUpvote(to: post.id)
+                            viewModel.replacePost(mutablePost)
                         }
                     }
                 }
@@ -237,7 +237,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.upvote(post: &mutablePost)
                     await MainActor.run {
                         if mutablePost.upvoted {
-                            viewModel.applyLocalUpvote(to: post.id)
+                            viewModel.replacePost(mutablePost)
                         }
                     }
                 }
@@ -259,7 +259,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.upvote(post: &mutablePost)
                     await MainActor.run {
                         if mutablePost.upvoted {
-                            viewModel.applyLocalUpvote(to: post.id)
+                            viewModel.replacePost(mutablePost)
                         }
                     }
                 }
@@ -270,7 +270,7 @@ public struct FeedView<NavigationStore: NavigationStoreProtocol>: View {
                     await votingViewModel.unvote(post: &mutablePost)
                     await MainActor.run {
                         if !mutablePost.upvoted {
-                            viewModel.applyLocalUpvote(to: post.id)
+                            viewModel.replacePost(mutablePost)
                         }
                     }
                 }
@@ -374,7 +374,7 @@ struct PostRowView: View {
     let onLinkTap: (() -> Void)?
     let onCommentsTap: (() -> Void)?
     let showThumbnails: Bool
-    let onUpvoteApplied: ((Int) -> Void)?
+    let onPostUpdated: ((Domain.Post) -> Void)?
     let onBookmarkToggle: (() async -> Bool)?
 
     init(post: Domain.Post,
@@ -382,7 +382,7 @@ struct PostRowView: View {
          showThumbnails: Bool = true,
          onLinkTap: (() -> Void)? = nil,
          onCommentsTap: (() -> Void)? = nil,
-         onUpvoteApplied: ((Int) -> Void)? = nil,
+         onPostUpdated: ((Domain.Post) -> Void)? = nil,
          onBookmarkToggle: (() async -> Bool)? = nil)
     {
         self.post = post
@@ -390,7 +390,7 @@ struct PostRowView: View {
         self.onLinkTap = onLinkTap
         self.onCommentsTap = onCommentsTap
         self.showThumbnails = showThumbnails
-        self.onUpvoteApplied = onUpvoteApplied
+        self.onPostUpdated = onPostUpdated
         self.onBookmarkToggle = onBookmarkToggle
     }
 
@@ -431,7 +431,7 @@ struct PostRowView: View {
 
         if wasUpvoted {
             await MainActor.run {
-                onUpvoteApplied?(mutablePost.id)
+                onPostUpdated?(mutablePost)
             }
         }
 
@@ -447,7 +447,7 @@ struct PostRowView: View {
 
         if wasUnvoted {
             await MainActor.run {
-                onUpvoteApplied?(mutablePost.id)
+                onPostUpdated?(mutablePost)
             }
         }
 

--- a/Features/Feed/Sources/Feed/FeedViewModel.swift
+++ b/Features/Feed/Sources/Feed/FeedViewModel.swift
@@ -237,14 +237,9 @@ public final class FeedViewModel: @unchecked Sendable {
         if let index = feedLoader.data.firstIndex(where: { $0.id == updatedPost.id }) {
             feedLoader.data[index] = updatedPost
         }
-    }
-
-    @MainActor
-    public func applyLocalUpvote(to postId: Int) {
-        guard let index = feedLoader.data.firstIndex(where: { $0.id == postId }) else { return }
-        guard feedLoader.data[index].upvoted == false else { return }
-        feedLoader.data[index].upvoted = true
-        feedLoader.data[index].score += 1
+        if let searchIndex = searchResults.firstIndex(where: { $0.id == updatedPost.id }) {
+            searchResults[searchIndex] = updatedPost
+        }
     }
 
     @MainActor

--- a/Features/Feed/Tests/FeedTests/FeedViewModelTests.swift
+++ b/Features/Feed/Tests/FeedTests/FeedViewModelTests.swift
@@ -359,6 +359,14 @@ private final class StubVoteUseCase: VoteUseCase, @unchecked Sendable {
     func upvote(comment _: Domain.Comment, for _: Post) async throws {
         if shouldThrow { throw StubError.network }
     }
+
+    func unvote(post _: Post) async throws {
+        if shouldThrow { throw StubError.network }
+    }
+
+    func unvote(comment _: Domain.Comment, for _: Post) async throws {
+        if shouldThrow { throw StubError.network }
+    }
 }
 
 private final class StubBookmarksUseCase: BookmarksUseCase, @unchecked Sendable {

--- a/Features/Feed/Tests/FeedTests/FeedViewTests.swift
+++ b/Features/Feed/Tests/FeedTests/FeedViewTests.swift
@@ -113,7 +113,9 @@ struct FeedViewTests {
             // Not used in feed
         }
 
-        // Unvote removed
+        func unvote(post _: Post) async throws {}
+
+        func unvote(comment _: Domain.Comment, for _: Post) async throws {}
     }
 
     final class MockBookmarksUseCase: BookmarksUseCase, @unchecked Sendable {

--- a/Shared/Sources/Shared/ViewModels/VotingViewModel.swift
+++ b/Shared/Sources/Shared/ViewModels/VotingViewModel.swift
@@ -86,6 +86,11 @@ public final class VotingViewModel {
         post.upvoted = false
         post.score -= 1
 
+        // Clear unvote link after successful unvote
+        if let existingLinks = post.voteLinks {
+            post.voteLinks = VoteLinks(upvote: existingLinks.upvote, unvote: nil)
+        }
+
         isVoting = true
         lastError = nil
 

--- a/Shared/Tests/SharedTests/DependencyContainerTests.swift
+++ b/Shared/Tests/SharedTests/DependencyContainerTests.swift
@@ -121,6 +121,8 @@ private final class StubPostRepository: PostUseCase, VoteUseCase, CommentUseCase
     func getComments(for _: Post) async throws -> [Domain.Comment] { [] }
     func upvote(post _: Post) async throws {}
     func upvote(comment _: Domain.Comment, for _: Post) async throws {}
+    func unvote(post _: Post) async throws {}
+    func unvote(comment _: Domain.Comment, for _: Post) async throws {}
 }
 
 private final class StubSettingsUseCase: SettingsUseCase, @unchecked Sendable {
@@ -144,6 +146,10 @@ private final class StubVotingStateProvider:
     func upvote(item _: any Votable) async throws {}
     func upvoteComment(_ comment: Domain.Comment, for _: Post) async throws {
         comment.upvoted = true
+    }
+    func unvote(item _: any Votable) async throws {}
+    func unvoteComment(_ comment: Domain.Comment, for _: Post) async throws {
+        comment.upvoted = false
     }
 }
 


### PR DESCRIPTION
Implement the ability to unvote posts and comments within the 1-hour window that Hacker News allows. The unvote option appears automatically when an unvote link is available from the server.

Changes:
- Add unvote methods to VoteUseCase protocol
- Implement unvote in PostRepository for posts and comments
- Update VotingState to track unvote availability with canUnvote property
- Add unvote to VotingStateProvider protocol and DefaultVotingStateProvider
- Update VotingViewModel with unvote methods and optimistic UI updates
- Update VoteButton to enable interaction when unvote is available
- Add unvote options to VotingContextMenuItems for posts and comments
- Update PostDisplayView to support unvote with toggle between upvote/unvote
- Add unvote swipe actions and context menus in FeedView
- Add unvote swipe actions and context menus in CommentsView for posts and comments

The feature includes:
- Optimistic UI updates with automatic rollback on error
- Swipe actions (orange arrow.uturn.down icon for unvote)
- Context menu options
- Proper accessibility labels and hints
- Automatic detection of unvote availability based on server response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now remove (undo) upvotes on posts and comments via vote buttons, context menus and swipe actions.
  * UI shows when unvoting is available, updates accessibility labels/hints, and preserves visual state during unvote flows.
  * Feed, comments and search synchronise updated posts after unvote.

* **Bug Fixes**
  * Optimistic unvote updates with automatic rollback on error; handles unauthenticated cases gracefully.

* **Tests**
  * Added test coverage for unvote behaviour across multiple suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->