### PR TITLE
Remove padding from comment separator views

### DIFF
--- a/Features/Comments/Sources/Comments/CommentsComponents.swift
+++ b/Features/Comments/Sources/Comments/CommentsComponents.swift
@@ -163,7 +163,7 @@ struct CommentsForEach: View {
                     value: [comment.id: geometry.frame(in: .global)],
                 )
             })
-            .listRowSeparator(.hidden)
+            .listRowSeparator(.visible)
             .if(comment.voteLinks?.upvote != nil && !comment.upvoted) { view in
                 view.swipeActions(edge: .leading, allowsFullSwipe: true) {
                     Button {
@@ -274,7 +274,6 @@ struct CommentRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Divider().padding(.bottom, 6)
             HStack {
                 Text(comment.by)
                     .scaledFont(.subheadline)

--- a/Features/Comments/Sources/Comments/CommentsComponents.swift
+++ b/Features/Comments/Sources/Comments/CommentsComponents.swift
@@ -307,11 +307,12 @@ struct CommentRow: View {
                     .foregroundColor(.primary)
             }
         }
-        .listRowInsets(.init(top: 12, leading: CGFloat((comment.level + 1) * 16), bottom: 8, trailing: 16))
+        .listRowInsets([.top, .bottom, .trailing], 16)
+        .listRowInsets([.leading], CGFloat((comment.level + 1) * 16))
         .contentShape(Rectangle())
         .onTapGesture { onToggle() }
         .accessibilityAddTraits(.isButton)
-        .accessibilityHint(comment.visibility == .visible ? "Double-tap to collapse" : "Double-tap to expand")
+        .accessibilityHint(comment.visibility == .visible ? "Tap to collapse" : "Tap to expand")
         .contextMenu {
             VotingContextMenuItems.commentVotingMenuItems(
                 for: comment,


### PR DESCRIPTION
- Removed custom Divider with padding from CommentRow
- Changed listRowSeparator from .hidden to .visible
- Native separator automatically adjusts width based on comment hierarchy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Simplified accessibility hint text for comment interactions

* **Style**
  * Improved indentation for nested comments to enhance visual hierarchy
  * Enhanced separator visibility in comments list
  * Refined overall comment thread layout for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->