### PR TITLE
Switch to Google's favicon service for thumbnails

### DIFF
--- a/DesignSystem/Sources/DesignSystem/Components/ThumbnailView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/ThumbnailView.swift
@@ -5,11 +5,15 @@
 //  Copyright © 2025 Weiran Zhang. All rights reserved.
 //
 
+import CoreGraphics
+import ImageIO
 import SwiftUI
 
 public struct ThumbnailView: View {
     let url: URL?
     let isEnabled: Bool
+
+    @State private var image: Image?
 
     public init(url: URL?, isEnabled: Bool = true) {
         self.url = url
@@ -37,14 +41,52 @@ public struct ThumbnailView: View {
             .background(Color.secondary.opacity(0.1))
     }
 
+    private func loadThumbnail(from thumbnailURL: URL) async {
+        await MainActor.run {
+            image = nil
+        }
+
+        var request = URLRequest(url: thumbnailURL)
+        request.cachePolicy = .returnCacheDataElseLoad
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            // Google responds with 404 when it serves its own fallback icon; treat that as missing.
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return }
+
+            guard let cgImage = cgImage(from: data) else { return }
+            let swiftUIImage = Image(decorative: cgImage, scale: 1, orientation: .up)
+
+            await MainActor.run {
+                image = swiftUIImage
+            }
+        } catch {
+            await MainActor.run {
+                image = nil
+            }
+        }
+    }
+
+    private func cgImage(from data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
     public var body: some View {
         if isEnabled, let url, let thumbnailURL = thumbnailURL(for: url) {
-            AsyncImage(url: thumbnailURL) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } placeholder: {
-                placeholderImage
+            ZStack {
+                if let image {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    placeholderImage
+                }
+            }
+            .task(id: thumbnailURL) {
+                await loadThumbnail(from: thumbnailURL)
             }
             .accessibilityHidden(true)
         } else {

--- a/DesignSystem/Sources/DesignSystem/Components/ThumbnailView.swift
+++ b/DesignSystem/Sources/DesignSystem/Components/ThumbnailView.swift
@@ -17,12 +17,15 @@ public struct ThumbnailView: View {
     }
 
     private func thumbnailURL(for url: URL) -> URL? {
+        guard let host = url.host else { return nil }
         var components = URLComponents()
         components.scheme = "https"
-        components.host = "hackers-thumbnails.weiranzhang.com"
-        components.path = "/api/FetchThumbnail"
-        let urlString = url.absoluteString
-        components.queryItems = [URLQueryItem(name: "url", value: urlString)]
+        components.host = "www.google.com"
+        components.path = "/s2/favicons"
+        components.queryItems = [
+            URLQueryItem(name: "domain", value: host),
+            URLQueryItem(name: "sz", value: "128")
+        ]
         return components.url
     }
 


### PR DESCRIPTION
Replace custom hackers-thumbnails service with Google's favicon API
which extracts the domain from URLs and requests 128px favicons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable and faster thumbnail loading using an updated external favicon service and a custom load-and-render flow.
  * Smoother in-app browsing with improved navigation state handling and asynchronous page loading.

* **New Features**
  * Added an "Open in Safari" action and explicit Back/Forward/Reload controls (including an iPad-specific bottom bar) for easier navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->