### PR TITLE
Gate custom browser feature behind development-only toggle

### DIFF
--- a/Data/Sources/Data/SettingsRepository.swift
+++ b/Data/Sources/Data/SettingsRepository.swift
@@ -22,9 +22,15 @@ extension UserDefaults: UserDefaultsProtocol {}
 
 public final class SettingsRepository: SettingsUseCase, @unchecked Sendable {
     private let userDefaults: UserDefaultsProtocol
+    private let isCustomBrowserFeatureEnabled: Bool
 
     public init(userDefaults: UserDefaultsProtocol = UserDefaults.standard) {
         self.userDefaults = userDefaults
+        #if DEBUG
+        isCustomBrowserFeatureEnabled = true
+        #else
+        isCustomBrowserFeatureEnabled = false
+        #endif
         registerDefaults()
     }
 
@@ -32,7 +38,8 @@ public final class SettingsRepository: SettingsUseCase, @unchecked Sendable {
         migrateLinkBrowserModeIfNeeded()
 
         setDefaultIfNeeded(false, forKey: "safariReaderMode")
-        setDefaultIfNeeded(LinkBrowserMode.customBrowser.rawValue, forKey: "linkBrowserMode")
+        let defaultLinkBrowserMode: LinkBrowserMode = isCustomBrowserFeatureEnabled ? .customBrowser : .inAppBrowser
+        setDefaultIfNeeded(defaultLinkBrowserMode.rawValue, forKey: "linkBrowserMode")
         setDefaultIfNeeded(true, forKey: "ShowThumbnails")
         setDefaultIfNeeded(false, forKey: "RememberFeedCategory")
         setDefaultIfNeeded(TextSize.medium.rawValue, forKey: "textSize")
@@ -54,8 +61,9 @@ public final class SettingsRepository: SettingsUseCase, @unchecked Sendable {
             return
         }
 
-        // New installs default to the custom browser.
-        userDefaults.set(LinkBrowserMode.customBrowser.rawValue, forKey: "linkBrowserMode")
+        // New installs default to custom browser in development and in-app browser in production.
+        let defaultMode: LinkBrowserMode = isCustomBrowserFeatureEnabled ? .customBrowser : .inAppBrowser
+        userDefaults.set(defaultMode.rawValue, forKey: "linkBrowserMode")
     }
 
     private func setDefaultIfNeeded(_ value: Any, forKey key: String) {
@@ -74,10 +82,17 @@ public final class SettingsRepository: SettingsUseCase, @unchecked Sendable {
 
     public var linkBrowserMode: LinkBrowserMode {
         get {
-            LinkBrowserMode(rawValue: userDefaults.integer(forKey: "linkBrowserMode")) ?? .inAppBrowser
+            let storedMode = LinkBrowserMode(rawValue: userDefaults.integer(forKey: "linkBrowserMode")) ?? .inAppBrowser
+            guard isCustomBrowserFeatureEnabled == false || storedMode != .customBrowser else {
+                return .customBrowser
+            }
+            return storedMode == .customBrowser ? .inAppBrowser : storedMode
         }
         set {
-            userDefaults.set(newValue.rawValue, forKey: "linkBrowserMode")
+            let modeToStore = isCustomBrowserFeatureEnabled == false && newValue == .customBrowser
+                ? LinkBrowserMode.inAppBrowser
+                : newValue
+            userDefaults.set(modeToStore.rawValue, forKey: "linkBrowserMode")
         }
     }
 

--- a/Features/Settings/Sources/Settings/SettingsView.swift
+++ b/Features/Settings/Sources/Settings/SettingsView.swift
@@ -185,7 +185,9 @@ public struct SettingsView: View {
                 Section(header: Text("Browser")) {
                     Picker(selection: $viewModel.linkBrowserMode) {
                         Text("In-App Browser").tag(LinkBrowserMode.inAppBrowser)
+                        #if DEBUG
                         Text("Custom Browser").tag(LinkBrowserMode.customBrowser)
+                        #endif
                         Text("System Browser").tag(LinkBrowserMode.systemBrowser)
                     } label: {
                         Label("Open Links Using", systemImage: "safari")

--- a/Features/WhatsNew/Sources/WhatsNew/Views/WhatsNewView.swift
+++ b/Features/WhatsNew/Sources/WhatsNew/Views/WhatsNewView.swift
@@ -79,7 +79,9 @@ public struct WhatsNewView: View {
 
     private var actionButtons: some View {
         VStack(spacing: 12) {
+            #if DEBUG
             enableEmbeddedBrowserButton
+            #endif
             continueButton
         }
     }


### PR DESCRIPTION
### Motivation

- Prevent an unfinished embedded/custom browser feature from being enabled in production builds while keeping the option available for development and testing.
- Ensure new installs and migrated settings behave safely in production by defaulting to the existing in-app browser.

### Description

- Added a dev-only gate (`isCustomBrowserFeatureEnabled`) in `SettingsRepository` driven by `#if DEBUG` so the custom embedded browser is enabled only in debug builds.
- Changed default link browser behavior so development builds default to `.customBrowser` while production builds default to `.inAppBrowser` for new installs and defaults registration.
- Normalized persisted `.customBrowser` values in production by coercing stored/custom selections to `.inAppBrowser` when the feature is disabled, and prevented storing `.customBrowser` in production.
- Hid the "Custom Browser" picker option in `SettingsView` and the "Enable Embedded Browser" CTA in `WhatsNewView` behind `#if DEBUG` so non-debug builds cannot enable the feature via UI.

### Testing

- Ran `./run_tests.sh Data` which completed successfully and reported the Data tests passed.
- Ran `./run_tests.sh Settings` which completed successfully and reported the Settings tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0d817b408324ad33ba899bf18857)