### PR TITLE
Fix URL share copy payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: AckeeCZ/load-xcode-version@v1
+      - name: Install iOS Simulator Runtime
+        run: xcodebuild -downloadPlatform iOS
       - name: Make test script executable
         run: chmod +x ./run_tests.sh
       - name: Run Tests
@@ -41,5 +43,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: AckeeCZ/load-xcode-version@v1
+      - name: Install iOS Simulator Runtime
+        run: xcodebuild -downloadPlatform iOS
       - name: Build App
         run: xcodebuild -project Hackers.xcodeproj -scheme Hackers -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: AckeeCZ/load-xcode-version@v1
+      - name: Run Xcode First Launch Setup
+        run: sudo xcodebuild -runFirstLaunch
       - name: Install iOS Simulator Runtime
         run: xcodebuild -downloadPlatform iOS
       - name: Make test script executable
@@ -43,6 +45,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: AckeeCZ/load-xcode-version@v1
+      - name: Run Xcode First Launch Setup
+        run: sudo xcodebuild -runFirstLaunch
       - name: Install iOS Simulator Runtime
         run: xcodebuild -downloadPlatform iOS
       - name: Build App

--- a/Shared/Sources/Shared/Services/ContentSharePresenter.swift
+++ b/Shared/Sources/Shared/Services/ContentSharePresenter.swift
@@ -6,6 +6,7 @@
 //
 
 import Domain
+import LinkPresentation
 import SwiftUI
 import UIKit
 
@@ -16,25 +17,17 @@ public final class ContentSharePresenter: @unchecked Sendable {
 
     @MainActor
     public func sharePost(_ post: Post) {
-        let items: [Any] = [post.title, post.url]
-        showShareSheet(items: items)
+        showShareSheet(items: Self.items(for: post))
     }
 
     @MainActor
     public func shareURL(_ url: URL, title: String? = nil) {
-        var items: [Any] = []
-        if let title {
-            items.append(title)
-        }
-        items.append(url)
-        showShareSheet(items: items)
+        showShareSheet(items: Self.items(for: url, title: title))
     }
 
     @MainActor
     public func shareComment(_ comment: Comment) {
-        let text = comment.text.strippingHTML()
-        let items: [Any] = [text]
-        showShareSheet(items: items)
+        showShareSheet(items: Self.items(for: comment))
     }
 
     @MainActor
@@ -53,5 +46,63 @@ public final class ContentSharePresenter: @unchecked Sendable {
 
             rootViewController.present(activityVC, animated: true)
         }
+    }
+}
+
+extension ContentSharePresenter {
+    static func items(for post: Post) -> [Any] {
+        items(for: post.url, title: post.title)
+    }
+
+    static func items(for url: URL, title: String? = nil) -> [Any] {
+        [URLActivityItemSource(url: url, title: title)]
+    }
+
+    static func items(for comment: Comment) -> [Any] {
+        [comment.text.strippingHTML()]
+    }
+}
+
+final class URLActivityItemSource: NSObject, UIActivityItemSource {
+    let url: URL
+    private let title: String?
+
+    init(url: URL, title: String?) {
+        self.url = url
+        self.title = title
+    }
+
+    func activityViewControllerPlaceholderItem(_: UIActivityViewController) -> Any {
+        return url
+    }
+
+    func activityViewController(
+        _: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
+        if activityType == .copyToPasteboard {
+            return url.absoluteString
+        }
+
+        return url
+    }
+
+    func activityViewController(
+        _: UIActivityViewController,
+        subjectForActivityType activityType: UIActivity.ActivityType?
+    ) -> String {
+        if activityType == .copyToPasteboard {
+            return ""
+        }
+
+        return title ?? ""
+    }
+
+    func activityViewControllerLinkMetadata(_: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = title
+        metadata.url = url
+        metadata.originalURL = url
+        return metadata
     }
 }

--- a/Shared/Tests/SharedTests/ContentSharePresenterTests.swift
+++ b/Shared/Tests/SharedTests/ContentSharePresenterTests.swift
@@ -7,6 +7,7 @@
 
 @testable import Domain
 import Foundation
+import UIKit
 @testable import Shared
 import Testing
 
@@ -70,6 +71,76 @@ struct ContentSharePresenterTests {
     }
 
     // MARK: - Structure Tests
+
+    @Test("Post share uses a single URL-backed activity item")
+    func postShareItemsUseURLActivityItem() {
+        let post = createTestPost()
+
+        let items = ContentSharePresenter.items(for: post)
+
+        #expect(items.count == 1)
+        let source = items.first as? URLActivityItemSource
+        #expect(source?.url == post.url)
+    }
+
+    @Test("URL share copy item is the raw URL")
+    func urlShareCopyItemIsRawURL() {
+        let testURL = URL(string: "https://example.com/article")!
+        let source = URLActivityItemSource(url: testURL, title: "Example Article")
+        let activityViewController = UIActivityViewController(activityItems: [], applicationActivities: nil)
+
+        let placeholder = source.activityViewControllerPlaceholderItem(activityViewController)
+        let copyItem = source.activityViewController(
+            activityViewController,
+            itemForActivityType: .copyToPasteboard
+        )
+
+        #expect(placeholder as? URL == testURL)
+        #expect(copyItem as? String == testURL.absoluteString)
+        #expect(source.activityViewController(
+            activityViewController,
+            subjectForActivityType: .copyToPasteboard
+        ) == "")
+    }
+
+    @Test("URL share metadata preserves title and URL for preview")
+    func urlShareMetadataPreservesPreviewTitle() throws {
+        let testURL = URL(string: "https://example.com/article")!
+        let source = URLActivityItemSource(url: testURL, title: "Example Article")
+        let activityViewController = UIActivityViewController(activityItems: [], applicationActivities: nil)
+
+        let metadata = try #require(source.activityViewControllerLinkMetadata(activityViewController))
+
+        #expect(metadata.title == "Example Article")
+        #expect(metadata.url == testURL)
+        #expect(metadata.originalURL == testURL)
+    }
+
+    @Test("URL share works without a title")
+    func urlShareWorksWithoutTitle() {
+        let testURL = URL(string: "https://example.com/article")!
+        let items = ContentSharePresenter.items(for: testURL)
+        let source = items.first as? URLActivityItemSource
+        let activityViewController = UIActivityViewController(activityItems: [], applicationActivities: nil)
+
+        #expect(items.count == 1)
+        #expect(source?.activityViewController(
+            activityViewController,
+            itemForActivityType: nil
+        ) as? URL == testURL)
+        #expect(source?.activityViewController(
+            activityViewController,
+            subjectForActivityType: nil
+        ) == "")
+    }
+
+    @Test("Comment share still uses stripped text")
+    func commentShareItemsUseStrippedText() {
+        let items = ContentSharePresenter.items(for: createTestComment())
+
+        #expect(items.count == 1)
+        #expect(items.first as? String == "This is a test comment with HTML content.")
+    }
 
     @Test("Presenter can be called with different data types")
     func presenterCallStructure() async {


### PR DESCRIPTION
## Summary
- share post and URL actions through a URL-backed activity item
- return a plain raw URL string for the Copy action
- keep link metadata for share sheet previews and preserve comment text sharing

Fixes #337

## Tests
- ./run_tests.sh Shared
- xcodebuild -project Hackers.xcodeproj -scheme Hackers -destination 'id=042A49B2-2EE9-4201-9B7B-149439DC814A' -configuration Debug build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured sharing so share payloads are built via dedicated helpers, simplifying post, URL and comment sharing.

* **Tests**
  * Added comprehensive tests covering post, URL and comment sharing, metadata handling and copy-to-pasteboard behaviour.

* **Chores**
  * Updated CI to download the iOS Simulator runtime during test and build jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->