### PR TITLE
Phase 3: align SwiftSoup and Swift 6 settings

### DIFF
--- a/App/EmbeddedWebView.swift
+++ b/App/EmbeddedWebView.swift
@@ -566,7 +566,6 @@ private struct PostCommentsSheet: View {
             .fill(.background)
     }
 
-
     private func resolvedSafeAreaInsets(for proxy: GeometryProxy) -> UIEdgeInsets {
         if let insets = PresentationContextProvider.shared.keyWindow?.safeAreaInsets {
             return insets
@@ -751,7 +750,6 @@ private struct BrowserControlsView: View {
         .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 4)
     }
 
-
     private func controlButton(
         systemName: String,
         isEnabled: Bool = true,
@@ -803,7 +801,7 @@ private struct GlassCircleBackground: ViewModifier {
 }
 
 private enum ControlsHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+    static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }
@@ -915,7 +913,7 @@ private struct CollapsedPostHeaderLoadingView: View {
 }
 
 private enum CollapsedHeaderHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+    static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }

--- a/Data/Package.resolved
+++ b/Data/Package.resolved
@@ -1,31 +1,13 @@
 {
-  "originHash" : "7576bdd07658d2cfd96dd3e7a0614d6ddb17161200d27e88dff4237fef67dfc4",
+  "originHash" : "3fb3dd55cfd27b29c90337740b0853a90bbb76d4cf7515681ae419dd11450adf",
   "pins" : [
-    {
-      "identity" : "lrucache",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/LRUCache.git",
-      "state" : {
-        "revision" : "e0e9e039b33db8f2ef39b8e25607e38f46b13584",
-        "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "db0428bcfced386943c05ba8ea3e607baa715e45",
-        "version" : "2.11.0"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     }
   ],

--- a/Data/Package.swift
+++ b/Data/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(path: "../Domain"),
         .package(path: "../Networking"),
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.2")
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.4")
     ],
     targets: [
         .target(

--- a/DesignSystem/Package.resolved
+++ b/DesignSystem/Package.resolved
@@ -1,31 +1,13 @@
 {
-  "originHash" : "7b018e245ec46cd1aad9a26c024f26f8f16dabe8ec66b8270d0af8676e0910e1",
+  "originHash" : "cfc12554928ccfd67cc0e9595b44ad61b5b0bcab096626cc0b4e6a8a3f94978d",
   "pins" : [
-    {
-      "identity" : "lrucache",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/LRUCache.git",
-      "state" : {
-        "revision" : "e0e9e039b33db8f2ef39b8e25607e38f46b13584",
-        "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "4206bc7b8bd9a4ff8e9511211e1b4bff979ef9c4",
-        "version" : "2.11.1"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     }
   ],

--- a/Extensions/OpenInViewController.swift
+++ b/Extensions/OpenInViewController.swift
@@ -29,7 +29,7 @@ class OpenInViewController: UIViewController {
                             self.close()
                         }
                     } else {
-                        self.error()
+                        Task { @MainActor in self.error() }
                     }
                 },
             )

--- a/Features/Package.resolved
+++ b/Features/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "944ecf5d94500e9cadaca6ec72c8aa21820f6f136372c503cd78c667c3a9c5be",
+  "originHash" : "098a1e6999bb78a8ef6717830e168e943c5c4dc40d6fc1125a4b29bc5affb3b2",
   "pins" : [
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "a81b1a5ac933dee8c6cfccf05d5ffcc5eb8c7ec4",
-        "version" : "2.10.0"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     }
   ],

--- a/Hackers.xcodeproj/project.pbxproj
+++ b/Hackers.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			SWIFT_VERSION = 5.0;
+			SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -372,7 +372,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-			SWIFT_VERSION = 5.0;
+			SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -511,7 +511,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			SWIFT_VERSION = 5.0;
+			SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -541,7 +541,7 @@
 				PRODUCT_NAME = Hackers;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
-			SWIFT_VERSION = 5.0;
+			SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -608,7 +608,7 @@
 			repositoryURL = "https://github.com/scinfu/SwiftSoup.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.13.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Hackers.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hackers.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "944ecf5d94500e9cadaca6ec72c8aa21820f6f136372c503cd78c667c3a9c5be",
+  "originHash" : "98f4ae6451d863c10e91ef8c5ed868340f75ff7e8a195de3c7aa8835a0b56659",
   "pins" : [
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "a81b1a5ac933dee8c6cfccf05d5ffcc5eb8c7ec4",
-        "version" : "2.10.0"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     }
   ],

--- a/Shared/Package.resolved
+++ b/Shared/Package.resolved
@@ -1,31 +1,13 @@
 {
-  "originHash" : "440dcb9d6d379247c45c735b4fe7740229b1fc46a4f18d7b0bbf2efee81077bc",
+  "originHash" : "87474008d9ede1f56fc5a1a1a0437cd275eb2d90673537c3800030b7ac0fbf36",
   "pins" : [
-    {
-      "identity" : "lrucache",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/LRUCache.git",
-      "state" : {
-        "revision" : "e0e9e039b33db8f2ef39b8e25607e38f46b13584",
-        "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
     {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "4206bc7b8bd9a4ff8e9511211e1b4bff979ef9c4",
-        "version" : "2.11.1"
+        "revision" : "6c7915e16f729857aec3e99068c361e58a00ed68",
+        "version" : "2.13.4"
       }
     }
   ],

--- a/Shared/Sources/Shared/ViewModels/VotingViewModel.swift
+++ b/Shared/Sources/Shared/ViewModels/VotingViewModel.swift
@@ -19,12 +19,7 @@ public final class VotingViewModel {
     public var navigationStore: NavigationStoreProtocol?
 
     public var isVoting = false
-    // Persist error across instances to support test expectations
-    private static var _lastError: Error?
-    public var lastError: Error? {
-        get { Self._lastError }
-        set { Self._lastError = newValue }
-    }
+    public var lastError: Error?
 
     public init(
         votingStateProvider: VotingStateProvider,

--- a/Shared/Tests/SharedTests/VotingViewModelTests.swift
+++ b/Shared/Tests/SharedTests/VotingViewModelTests.swift
@@ -136,7 +136,7 @@ struct VotingViewModelTests {
         #expect(mockVotingStateProvider.upvoteCalled, "Upvote should be attempted")
         #expect(mockAuth.logoutCalled, "Logout should be called on unauthenticated error")
         #expect(nav.showLoginCalled, "Navigation should prompt login")
-        // lastError may be mutated concurrently in other tests due to static storage; do not assert on it here
+        #expect(viewModel.lastError == nil, "Unauthenticated errors should prompt login instead of showing an alert")
         #expect(post.upvoted == false && post.score == 10, "Optimistic state should be reverted")
     }
 
@@ -285,14 +285,15 @@ struct VotingViewModelTests {
         )
 
         mockCommentVotingStateProvider.shouldThrow = true
+        let viewModel = votingViewModel
 
         // When
-        await votingViewModel.upvote(comment: comment, in: post)
+        await viewModel.upvote(comment: comment, in: post)
 
         // Then - Should revert the optimistic update
         #expect(mockCommentVotingStateProvider.upvoteCommentCalled, "Upvote should be called")
         #expect(comment.upvoted == false, "Comment should be reverted to original state after error")
-        #expect(votingViewModel.lastError != nil, "Error should be set")
+        #expect(viewModel.lastError != nil, "Error should be set")
     }
 }
 


### PR DESCRIPTION
## Summary
- Align SwiftSoup requirement and resolved package pins to 2.13.4
- Move app project Swift language mode to Swift 6
- Fix Swift 6 issues in web view preference keys and action extension callback isolation
- Replace static voting error state with instance state

## Validation
- xcodebuild build -project Hackers.xcodeproj -scheme Hackers -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
- ./run_tests.sh
- swiftlint lint --config .swiftlint.yml --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Swift compiler version to 6.0
  * Updated core third-party library dependencies to latest versions

* **Bug Fixes**
  * Enhanced error handling to ensure UI-related operations execute on the main thread correctly
  * Corrected error state management to prevent cross-contamination between separate instances

* **Tests**
  * Updated test coverage to reflect error handling improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->